### PR TITLE
Feat: 공통 API 응답 형식 구현

### DIFF
--- a/src/main/java/com/example/i_commerce/global/common/response/ApiResponse.java
+++ b/src/main/java/com/example/i_commerce/global/common/response/ApiResponse.java
@@ -1,0 +1,21 @@
+package com.example.i_commerce.global.common.response;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiResponse<T> (
+    String code,
+    String message,
+    T data
+) {
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>( "SUCCESS","API 요청에 성공했습니다", data);
+    }
+
+    public static ApiResponse<Void> success() {
+        return new ApiResponse<>("SUCCESS","API 요청에 성공했습니다", null);
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/global/common/response/SliceResponse.java
+++ b/src/main/java/com/example/i_commerce/global/common/response/SliceResponse.java
@@ -1,0 +1,39 @@
+package com.example.i_commerce.global.common.response;
+
+import java.util.List;
+import java.util.function.Function;
+import org.springframework.data.domain.Slice;
+
+public record SliceResponse<T>(
+    List<T> content,
+    int sliceNumber,
+    int numberOfElements,
+    int size,
+    boolean hasNext,
+    boolean isFirst,
+    boolean isLast
+) {
+    public static <T> SliceResponse<T> of(Slice<T> slice) {
+        return new SliceResponse<>(
+            slice.getContent(),
+            slice.getNumber(),
+            slice.getNumberOfElements(),
+            slice.getSize(),
+            slice.hasNext(),
+            slice.isFirst(),
+            slice.isLast()
+        );
+    }
+
+    public static <T, R> SliceResponse<R> of(Slice<T> slice, Function<T, R> converter) {
+        return new SliceResponse<>(
+            slice.getContent().stream().map(converter).toList(),
+            slice.getNumber(),
+            slice.getNumberOfElements(),
+            slice.getSize(),
+            slice.hasNext(),
+            slice.isFirst(),
+            slice.isLast()
+        );
+    }
+}


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
- closed #2 -> develop


## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
- 파일 위치: global/common/response
- API 응답의 일관성을 위한 공통 응답 형식을 구현했습니다.

**변경 예시**

- 적용 전 응답
```json
{
    "id": 1,
    "name": "상품명",
    "price": 10000
}
```


- 적용 후 응답
```json
{
  "code": "SUCCESS",
  "message": "API 요청에 성공했습니다",
  "data": {
    "id": 1,
    "name": "상품명",
    "price": 10000
  }
}
```


**사용법** 

API응답시, 해당 객체로 감싸서 응답하면 됩니다!
- 보낼 데이터가 있는 경우 예시
```java
@PostMapping
public ApiResponse<ProductResponse> createProduct(@RequestBody ProductRequest request) {
    ProductResponse product = productService.create(request);
    return ApiResponse.success(product);
}
```


- 보낼 데이터가 없는 경우 (null) 예시
```java
@DeleteMapping("/{id}")
public ApiResponse<Void> deleteProduct(@PathVariable Long id) {
    productService.delete(id);
    return ApiResponse.success(); 
}
```


## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
- 에러 핸들러 개발하실 때도 해당 클래스 활용하시면 됩니다.
- 현재 성공한 경우의 응답 메세지는 `API 요청에 성공했습니다` 로 통일되어 있는데, 이것도 매개변수로 받는게 좋을지 의견을 듣고 싶습니다!
또는 다른 좋은 응답 메세지 의견 있으면 남겨주세요!
- 코드 관련 궁금하신 점, 개선할 점 있으시면 남겨주세요!



