### PR TITLE
Feat: 에러코드 식별자 추가

### DIFF
--- a/src/main/java/com/example/i_commerce/global/common/response/ApiResponse.java
+++ b/src/main/java/com/example/i_commerce/global/common/response/ApiResponse.java
@@ -21,6 +21,6 @@ public record ApiResponse<T> (
     }
 
     public static ApiResponse<?> error(ErrorCode errorCode, String message) {
-        return new ApiResponse<>(errorCode.getHttpStatus().toString(), message, null);
+        return new ApiResponse<>(errorCode.getCode(), message, errorCode.getHttpStatus().toString());
     }
 }

--- a/src/main/java/com/example/i_commerce/global/error/ErrorCode.java
+++ b/src/main/java/com/example/i_commerce/global/error/ErrorCode.java
@@ -8,21 +8,21 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-    // 공통 에러
-    INVALID_PERMISSION(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러가 발생했습니다."),
+    // --- 공통 에러 (COM) ---
+    INVALID_PERMISSION(HttpStatus.UNAUTHORIZED, "COM-40101", "권한이 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COM-50001", "서버 내부 에러가 발생했습니다."),
 
-    // Member 도메인
-    DUPLICATED_USER_NAME(HttpStatus.CONFLICT, "이미 존재하는 유저명입니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
-    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "패스워드가 틀렸습니다."),
+    // --- Member 도메인 (USR) ---
+    DUPLICATED_USER_NAME(HttpStatus.CONFLICT, "USR-40901", "이미 존재하는 유저명입니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "USR-40101", "패스워드가 틀렸습니다."),
 
-    // Post/Product 도메인
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),
-    ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 누른 게시글입니다.");
-
+    // --- Post/Product 도메인 (PRD) ---
+    // 게시글과 상품을 PRD(Product) 도메인으로 통합하여 구성했습니다.
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "PRD-40401", "해당 게시글을 찾을 수 없습니다."),
+    ALREADY_LIKED(HttpStatus.CONFLICT, "PRD-40901", "이미 좋아요를 누른 게시글입니다.");
 
     private final HttpStatus httpStatus;
+    private final String code;
     private final String message;
 
 }

--- a/src/main/java/com/example/i_commerce/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/i_commerce/global/error/GlobalExceptionHandler.java
@@ -1,8 +1,7 @@
 package com.example.i_commerce.global.error;
 
 import com.example.i_commerce.global.common.response.ApiResponse;
-import java.util.HashMap;
-import java.util.Map;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,7 +10,16 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(AppException.class)
-    public ApiResponse<?> appExceptionHandler(AppException e) {
-        return ApiResponse.error(e.getErrorCode(), e.getMessage());
+    public ResponseEntity<ApiResponse<?>> appExceptionHandler(AppException e) {
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(ApiResponse.error(e.getErrorCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<?>> handleAllException(Exception e) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage()));
     }
 }


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
closed #1 

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
- 에러 코드 구조 도입
에러 발생 시 즉각적인 디버깅과 클라이언트 대응을 위해 [도메인]-[HTTP상태코드][순번] 구조를 채택했습니다.
예시: USR-40401 (회원 도메인에서 발생한 404 Not Found 첫 번째 에러)
도메인 식별자: COM(공통), USR(회원), PRD(상품/게시글), ORD(주문), PAY(결제), REV(리뷰), CHT(채팅)

- GlobalExceptionHandler
@RestControllerAdvice를 통해 전역 예외를 포착하여 ResponseEntity<ApiResponse<Void>> 형태로 변환

## 😅 Uncompleted Tasks
[//]: # (없다면 N/A)
N/A

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)


