### PR TITLE
Feat: 주문 생성 API 구현

### DIFF
--- a/src/main/java/com/example/i_commerce/domain/member/entity/Member.java
+++ b/src/main/java/com/example/i_commerce/domain/member/entity/Member.java
@@ -58,7 +58,7 @@ public class Member extends BaseEntity {
 
     @Builder.Default
     @Column(nullable = false)
-    private Integer point;
+    private Integer point = 0;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/com/example/i_commerce/domain/member/entity/Member.java
+++ b/src/main/java/com/example/i_commerce/domain/member/entity/Member.java
@@ -88,8 +88,10 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PointHistory> pointHistories = new ArrayList<>();
 
-    @Builder.Default
-    @OneToMany(mappedBy = "member")
-    private List<ChatMessage> chatMessages = new ArrayList<>();
+//    @Builder.Default
+//    @OneToMany(mappedBy = "member")
+//    private List<ChatMessage> chatMessages = new ArrayList<>();
+
+
 
 }

--- a/src/main/java/com/example/i_commerce/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.example.i_commerce.domain.member.repository;
+
+import com.example.i_commerce.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/example/i_commerce/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/i_commerce/domain/order/controller/OrderController.java
@@ -1,7 +1,7 @@
 package com.example.i_commerce.domain.order.controller;
 
 import com.example.i_commerce.domain.order.service.OrderService;
-import com.example.i_commerce.domain.order.service.dto.OrderCreateDto;
+import com.example.i_commerce.domain.order.service.dto.CreateOrderRequest;
 import com.example.i_commerce.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -10,13 +10,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/orders")
+@RequestMapping("/api/v1/orders")
 public class OrderController {
 
     private final OrderService orderService;
 
     @PostMapping
-    public ApiResponse<?> createOrder(OrderCreateDto dto) {
+    public ApiResponse<Void> createOrder(CreateOrderRequest dto) {
         return orderService.createOrder(dto);
     }
 }

--- a/src/main/java/com/example/i_commerce/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/i_commerce/domain/order/controller/OrderController.java
@@ -1,0 +1,22 @@
+package com.example.i_commerce.domain.order.controller;
+
+import com.example.i_commerce.domain.order.service.OrderService;
+import com.example.i_commerce.domain.order.service.dto.OrderCreateDto;
+import com.example.i_commerce.global.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping
+    public ApiResponse<?> createOrder(OrderCreateDto dto) {
+        return orderService.createOrder(dto);
+    }
+}

--- a/src/main/java/com/example/i_commerce/domain/order/entity/Order.java
+++ b/src/main/java/com/example/i_commerce/domain/order/entity/Order.java
@@ -33,7 +33,7 @@ public class Order extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private String userId;
+    private Long userId;
 
     @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;

--- a/src/main/java/com/example/i_commerce/domain/order/entity/Order.java
+++ b/src/main/java/com/example/i_commerce/domain/order/entity/Order.java
@@ -44,6 +44,12 @@ public class Order extends BaseEntity {
 
     private Integer totalPayAmount;
 
+    @Column(length = 20)
+    private String receiverName;
+
+    @Column(length = 20)
+    private String receiverPhone;
+
     @Column(length = 10)
     private String zipCode;
 

--- a/src/main/java/com/example/i_commerce/domain/order/entity/Order.java
+++ b/src/main/java/com/example/i_commerce/domain/order/entity/Order.java
@@ -44,12 +44,6 @@ public class Order extends BaseEntity {
 
     private Integer totalPayAmount;
 
-    @Column(length = 20)
-    private String receiverName;
-
-    @Column(length = 20)
-    private String receiverPhone;
-
     @Column(length = 10)
     private String zipCode;
 

--- a/src/main/java/com/example/i_commerce/domain/order/entity/OrderProduct.java
+++ b/src/main/java/com/example/i_commerce/domain/order/entity/OrderProduct.java
@@ -34,11 +34,9 @@ public class OrderProduct extends BaseEntity {
     private Order order;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "payment_id", nullable = false)
-    private Payment payment;
+    @JoinColumn(name = "delivery_id", nullable = false)
+    private Delivery delivery;
 
-    @Column(nullable = false)
-    private Long deliveryId;
 
     @Column(nullable = false)
     private Long productSkuId;

--- a/src/main/java/com/example/i_commerce/domain/order/entity/Payment.java
+++ b/src/main/java/com/example/i_commerce/domain/order/entity/Payment.java
@@ -39,9 +39,6 @@ public class Payment extends BaseEntity {
     @JoinColumn(name = "order_id", nullable = false)
     private Order order;
 
-//    @Column(nullable = false)
-//    private Long orderId;
-
   /*  @Enumerated(EnumType.STRING)
     private  method;*/
 
@@ -56,9 +53,5 @@ public class Payment extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "payment", cascade = CascadeType.ALL)
     private List<PaymentHistory> paymentHistories = new ArrayList<>();
-
-    @Builder.Default
-    @OneToMany(mappedBy = "payment", cascade = CascadeType.ALL)
-    private List<OrderProduct> payments = new ArrayList<>();
 
 }

--- a/src/main/java/com/example/i_commerce/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/order/repository/OrderRepository.java
@@ -1,0 +1,8 @@
+package com.example.i_commerce.domain.order.repository;
+
+import com.example.i_commerce.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}
+

--- a/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
@@ -33,7 +33,7 @@ public class OrderService {
 
         // 주문 생성
         Member member = memberRepository.findById(dto.memberId())
-                .orElseThrow(() -> new AppException(ErrorCode.ORDER_TEMP_ERROR));
+                .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
 
         List<Long> ids = dto.items().stream().map(OrderItemDto::productId).toList();
         List<ProductItem> productItems = productItemRepository.findAllById(ids);
@@ -45,7 +45,7 @@ public class OrderService {
                     ProductItem productItem = productMap.get(orderItemDto.productId());
 
                     if(productItem == null) {
-                        throw new AppException(ErrorCode.ORDER_TEMP_ERROR);
+                        throw new AppException(ErrorCode.PRODUCT_NOT_FOUND);
                     }
 
                     return OrderProduct.builder()
@@ -65,7 +65,7 @@ public class OrderService {
         DeliveryAddress deliveryAddress = member.getDeliveryAddresses().stream()
                 .filter(DeliveryAddress::getIsDefault)
                 .findFirst()
-                .orElseThrow(() -> new AppException(ErrorCode.ORDER_TEMP_ERROR));
+                .orElseThrow(() -> new AppException(ErrorCode.DEFAULT_ADDRESS_NOT_FOUND));
 
         orderRepository.save(Order.builder()
                 .userId(dto.memberId())

--- a/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
@@ -7,7 +7,7 @@ import com.example.i_commerce.domain.order.entity.Order;
 import com.example.i_commerce.domain.order.entity.OrderProduct;
 import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
 import com.example.i_commerce.domain.order.repository.OrderRepository;
-import com.example.i_commerce.domain.order.service.dto.OrderCreateDto;
+import com.example.i_commerce.domain.order.service.dto.CreateOrderRequest;
 import com.example.i_commerce.domain.order.service.dto.OrderItemDto;
 import com.example.i_commerce.domain.product.entity.ProductItem;
 import com.example.i_commerce.domain.product.repository.ProductItemRepository;
@@ -29,7 +29,7 @@ public class OrderService {
     private final ProductItemRepository productItemRepository;
     private final MemberRepository memberRepository;
 
-    public ApiResponse<?> createOrder(OrderCreateDto dto) {
+    public ApiResponse<Void> createOrder(CreateOrderRequest dto) {
 
         // 주문 생성
         Member member = memberRepository.findById(dto.memberId())

--- a/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
@@ -1,0 +1,89 @@
+package com.example.i_commerce.domain.order.service;
+
+import com.example.i_commerce.domain.member.entity.DeliveryAddress;
+import com.example.i_commerce.domain.member.entity.Member;
+import com.example.i_commerce.domain.member.repository.MemberRepository;
+import com.example.i_commerce.domain.order.entity.Order;
+import com.example.i_commerce.domain.order.entity.OrderProduct;
+import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
+import com.example.i_commerce.domain.order.repository.OrderRepository;
+import com.example.i_commerce.domain.order.service.dto.OrderCreateDto;
+import com.example.i_commerce.domain.order.service.dto.OrderItemDto;
+import com.example.i_commerce.domain.product.entity.ProductItem;
+import com.example.i_commerce.domain.product.repository.ProductItemRepository;
+import com.example.i_commerce.global.common.response.ApiResponse;
+import com.example.i_commerce.global.error.AppException;
+import com.example.i_commerce.global.error.ErrorCode;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final ProductItemRepository productItemRepository;
+    private final MemberRepository memberRepository;
+
+    public ApiResponse<?> createOrder(OrderCreateDto dto) {
+
+        // 주문 생성
+        Member member = memberRepository.findById(dto.memberId())
+                .orElseThrow(() -> new AppException(ErrorCode.ORDER_TEMP_ERROR));
+
+        List<Long> ids = dto.items().stream().map(OrderItemDto::productId).toList();
+        List<ProductItem> productItems = productItemRepository.findAllById(ids);
+
+        Map<Long, ProductItem> productMap = productItems.stream().collect(Collectors.toMap(ProductItem::getId, Function.identity()));
+
+        List<OrderProduct> orderProducts = dto.items().stream()
+                .map(orderItemDto -> {
+                    ProductItem productItem = productMap.get(orderItemDto.productId());
+
+                    if(productItem == null) {
+                        throw new AppException(ErrorCode.ORDER_TEMP_ERROR);
+                    }
+
+                    return OrderProduct.builder()
+                            .productSkuId(productItem.getId())
+                            .productName(productItem.getProduct().getName())
+                            .orderPrice(productItem.getPrice())
+                            .count(orderItemDto.quantity())
+                            .build();
+
+                })
+                .toList();
+
+        int totalPrice = orderProducts.stream()
+                .mapToInt(op -> op.getOrderPrice() * op.getCount())
+                .sum();
+
+        DeliveryAddress deliveryAddress = member.getDeliveryAddresses().stream()
+                .filter(DeliveryAddress::getIsDefault)
+                .findFirst()
+                .orElseThrow(() -> new AppException(ErrorCode.ORDER_TEMP_ERROR));
+
+        orderRepository.save(Order.builder()
+                .userId(dto.memberId())
+                .orderStatus(OrderStatus.PENDING)
+                .orderProducts(orderProducts)
+                .totalProductAmount(totalPrice) // 총 금액
+                .totalPayAmount(totalPrice) // 실제 결제 금액
+                .zipCode(deliveryAddress.getZipCode())
+                .address(deliveryAddress.getRoadAddress())
+                .addressDetail(deliveryAddress.getDetailAddress())
+                .build());
+
+        // 결제
+
+        // 배송
+
+        return ApiResponse.success();
+
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/domain/order/service/dto/CreateOrderRequest.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/dto/CreateOrderRequest.java
@@ -2,7 +2,7 @@ package com.example.i_commerce.domain.order.service.dto;
 
 import java.util.List;
 
-public record OrderCreateDto(
+public record CreateOrderRequest(
         Long memberId,
         // Long point
         List<OrderItemDto> items

--- a/src/main/java/com/example/i_commerce/domain/order/service/dto/OrderCreateDto.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/dto/OrderCreateDto.java
@@ -1,0 +1,10 @@
+package com.example.i_commerce.domain.order.service.dto;
+
+import java.util.List;
+
+public record OrderCreateDto(
+        Long memberId,
+        // Long point
+        List<OrderItemDto> items
+) {
+}

--- a/src/main/java/com/example/i_commerce/domain/order/service/dto/OrderItemDto.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/dto/OrderItemDto.java
@@ -1,0 +1,7 @@
+package com.example.i_commerce.domain.order.service.dto;
+
+public record OrderItemDto(
+        Long productId,
+        int quantity
+) {
+}

--- a/src/main/java/com/example/i_commerce/domain/product/repository/ProductItemRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/ProductItemRepository.java
@@ -1,0 +1,7 @@
+package com.example.i_commerce.domain.product.repository;
+
+import com.example.i_commerce.domain.product.entity.ProductItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductItemRepository extends JpaRepository<ProductItem, Long> {
+}

--- a/src/main/java/com/example/i_commerce/global/error/ErrorCode.java
+++ b/src/main/java/com/example/i_commerce/global/error/ErrorCode.java
@@ -15,11 +15,20 @@ public enum ErrorCode {
     // --- Member 도메인 (USR) ---
     DUPLICATED_USER_NAME(HttpStatus.CONFLICT, "USR-40901", "이미 존재하는 유저명입니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "USR-40101", "패스워드가 틀렸습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USR-40401", "존재하지 않는 회원입니다."),
+    DEFAULT_ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "USR-40402", "기본 배송지가 설정되지 않았습니다."),
+
 
     // --- Post/Product 도메인 (PRD) ---
     // 게시글과 상품을 PRD(Product) 도메인으로 통합하여 구성했습니다.
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "PRD-40401", "해당 게시글을 찾을 수 없습니다."),
-    ALREADY_LIKED(HttpStatus.CONFLICT, "PRD-40901", "이미 좋아요를 누른 게시글입니다.");
+    ALREADY_LIKED(HttpStatus.CONFLICT, "PRD-40901", "이미 좋아요를 누른 게시글입니다."),
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "PRD-40402", "상품 정보를 찾을 수 없습니다."),
+
+
+
+    // --- Order/Payment 도메인 (ORD) ---
+    ORDER_TEMP_ERROR(HttpStatus.NOT_FOUND, "ORD-40400", "order도메인에서 발생하는 임시 에러입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/test/java/com/example/i_commerce/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/service/OrderServiceTest.java
@@ -97,7 +97,7 @@ class OrderServiceTest {
         when(productItemRepository.findAllById(anyList())).thenReturn(List.of());
 
         AppException exception = assertThrows(AppException.class, () -> orderService.createOrder(dto));
-        assertEquals(ErrorCode.ORDER_TEMP_ERROR, exception.getErrorCode());
+        assertEquals(ErrorCode.PRODUCT_NOT_FOUND, exception.getErrorCode());
     }
 
 

--- a/src/test/java/com/example/i_commerce/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/service/OrderServiceTest.java
@@ -8,7 +8,7 @@ import com.example.i_commerce.domain.member.entity.DeliveryAddress;
 import com.example.i_commerce.domain.member.entity.Member;
 import com.example.i_commerce.domain.member.repository.MemberRepository;
 import com.example.i_commerce.domain.order.repository.OrderRepository;
-import com.example.i_commerce.domain.order.service.dto.OrderCreateDto;
+import com.example.i_commerce.domain.order.service.dto.CreateOrderRequest;
 import com.example.i_commerce.domain.order.service.dto.OrderItemDto;
 import com.example.i_commerce.domain.product.entity.Product;
 import com.example.i_commerce.domain.product.entity.ProductItem;
@@ -66,7 +66,7 @@ class OrderServiceTest {
     void createOrder_success_multipleItems() {
         OrderItemDto item1Dto = OrderFixture.createItemDto(100L, 2);
         OrderItemDto item2Dto = OrderFixture.createItemDto(200L, 3);
-        OrderCreateDto dto = OrderFixture.createOrderDto(OrderFixture.MEMBER_ID, item1Dto, item2Dto);
+        CreateOrderRequest dto = OrderFixture.createOrderDto(OrderFixture.MEMBER_ID, item1Dto, item2Dto);
 
         Member member = createMockMember();
 
@@ -91,7 +91,7 @@ class OrderServiceTest {
     @Test
     @DisplayName("실패: 상품 중 하나라도 존재하지 않으면 예외가 발생한다")
     void createOrder_fail_itemNotFound() {
-        OrderCreateDto dto = OrderFixture.createOrderDto(OrderFixture.MEMBER_ID, OrderFixture.createItemDto(999L, 1));
+        CreateOrderRequest dto = OrderFixture.createOrderDto(OrderFixture.MEMBER_ID, OrderFixture.createItemDto(999L, 1));
 
         when(memberRepository.findById(OrderFixture.MEMBER_ID)).thenReturn(Optional.of(mock(Member.class)));
         when(productItemRepository.findAllById(anyList())).thenReturn(List.of());
@@ -108,8 +108,8 @@ class OrderServiceTest {
         public static final String DETAIL_ADDRESS = "101호";
 
         // 주문 요청 DTO 생성 헬퍼
-        public static OrderCreateDto createOrderDto(Long userId, OrderItemDto... items) {
-            return new OrderCreateDto(userId, List.of(items));
+        public static CreateOrderRequest createOrderDto(Long userId, OrderItemDto... items) {
+            return new CreateOrderRequest(userId, List.of(items));
         }
 
         // 개별 아이템 DTO 생성 헬퍼

--- a/src/test/java/com/example/i_commerce/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/service/OrderServiceTest.java
@@ -1,0 +1,120 @@
+package com.example.i_commerce.domain.order.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.example.i_commerce.domain.member.entity.DeliveryAddress;
+import com.example.i_commerce.domain.member.entity.Member;
+import com.example.i_commerce.domain.member.repository.MemberRepository;
+import com.example.i_commerce.domain.order.repository.OrderRepository;
+import com.example.i_commerce.domain.order.service.dto.OrderCreateDto;
+import com.example.i_commerce.domain.order.service.dto.OrderItemDto;
+import com.example.i_commerce.domain.product.entity.Product;
+import com.example.i_commerce.domain.product.entity.ProductItem;
+import com.example.i_commerce.domain.product.repository.ProductItemRepository;
+import com.example.i_commerce.global.common.response.ApiResponse;
+import com.example.i_commerce.global.error.AppException;
+import com.example.i_commerce.global.error.ErrorCode;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Mock
+    ProductItemRepository productItemRepository;
+
+    @Mock
+    OrderRepository orderRepository;
+
+    @InjectMocks
+    OrderService orderService;
+
+    private Member createMockMember() {
+        Member member = mock(Member.class);
+        DeliveryAddress address = mock(DeliveryAddress.class);
+        when(address.getIsDefault()).thenReturn(true);
+        when(address.getZipCode()).thenReturn(OrderFixture.ZIP_CODE);
+        when(address.getRoadAddress()).thenReturn(OrderFixture.ADDRESS);
+        when(address.getDetailAddress()).thenReturn(OrderFixture.DETAIL_ADDRESS);
+        when(member.getDeliveryAddresses()).thenReturn(List.of(address));
+        return member;
+    }
+
+    private ProductItem createMockProductItem(Long id, int price, String name) {
+        ProductItem item = mock(ProductItem.class);
+        Product product = mock(Product.class);
+        when(item.getId()).thenReturn(id);
+        when(item.getPrice()).thenReturn(price);
+        when(item.getProduct()).thenReturn(product);
+        when(product.getName()).thenReturn(name);
+        return item;
+    }
+
+    @Test
+    @DisplayName("성공: 다중 상품 주문 시 총액이 정확히 계산되고 저장된다")
+    void createOrder_success_multipleItems() {
+        OrderItemDto item1Dto = OrderFixture.createItemDto(100L, 2);
+        OrderItemDto item2Dto = OrderFixture.createItemDto(200L, 3);
+        OrderCreateDto dto = OrderFixture.createOrderDto(OrderFixture.MEMBER_ID, item1Dto, item2Dto);
+
+        Member member = createMockMember();
+
+        ProductItem p1 = createMockProductItem(100L, 10000, "상품1");
+        ProductItem p2 = createMockProductItem(200L, 5000, "상품2");
+
+        when(memberRepository.findById(OrderFixture.MEMBER_ID)).thenReturn(Optional.of(member));
+        when(productItemRepository.findAllById(anyList())).thenReturn(List.of(p1, p2));
+
+        ApiResponse<?> response = orderService.createOrder(dto);
+
+        assertEquals("SUCCESS", response.code());
+
+        // 합계 검증: (10000 * 2) + (5000 * 3) = 35000
+        verify(orderRepository).save(argThat(order ->
+                order.getTotalProductAmount() == 35000 &&
+                        order.getZipCode().equals(OrderFixture.ZIP_CODE) &&
+                        order.getOrderProducts().size() == 2
+        ));
+    }
+
+    @Test
+    @DisplayName("실패: 상품 중 하나라도 존재하지 않으면 예외가 발생한다")
+    void createOrder_fail_itemNotFound() {
+        OrderCreateDto dto = OrderFixture.createOrderDto(OrderFixture.MEMBER_ID, OrderFixture.createItemDto(999L, 1));
+
+        when(memberRepository.findById(OrderFixture.MEMBER_ID)).thenReturn(Optional.of(mock(Member.class)));
+        when(productItemRepository.findAllById(anyList())).thenReturn(List.of());
+
+        AppException exception = assertThrows(AppException.class, () -> orderService.createOrder(dto));
+        assertEquals(ErrorCode.ORDER_TEMP_ERROR, exception.getErrorCode());
+    }
+
+
+    public static class OrderFixture {
+        public static final Long MEMBER_ID = 1L;
+        public static final String ZIP_CODE = "12345";
+        public static final String ADDRESS = "서울시 강남구";
+        public static final String DETAIL_ADDRESS = "101호";
+
+        // 주문 요청 DTO 생성 헬퍼
+        public static OrderCreateDto createOrderDto(Long userId, OrderItemDto... items) {
+            return new OrderCreateDto(userId, List.of(items));
+        }
+
+        // 개별 아이템 DTO 생성 헬퍼
+        public static OrderItemDto createItemDto(Long productId, int quantity) {
+            return new OrderItemDto(productId, quantity);
+        }
+    }
+}


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
closed #11 

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
- 주문 생성 API생성
- 타 도메인에서 필요한 Repository, ErrorCode추가

## 😅 Uncompleted Tasks
[//]: # (없다면 N/A)
- N/A

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
시원님
- ProductItemRepository 추가했습니다.
- ErrorCode에 상품이 조회가 안될 경우 필요한 PRODUCT_NOT_FOUND를 추가해 뒀습니다.

준영님
-  MemberRepository 추가했습니다.
- ErrorCode에 유저 정보와 기본 주소 조회가 안될 경우 필요한 USER_NOT_FOUND, DEFAULT_ADDRESS_NOT_FOUND 추가해 두었으니 확인 부탁드려요 
- Member 엔티티의 chatMessages에 mappedBy가 설정되어 있는데, 현재 ChatMessage 엔티티에 @ManyToOne 참조가 없어 빌드 시 에러가 발생하고 있어 일단 주석 처리해두었습니다.
- 처음에 논의했던 것처럼 Member와 ChatMessage가 서로 다른 도메인이라면 이렇게 객체로 직접 참조하기보다 ID로만 참조하는 방식이 나중에 서비스를 분리할 때 훨씬 유연할 것 같습니다~


