### PR TITLE
Fix: 상품과 재고의 잘못된 연관관계 수정

### DIFF
--- a/src/main/java/com/example/i_commerce/domain/product/entity/ProductItem.java
+++ b/src/main/java/com/example/i_commerce/domain/product/entity/ProductItem.java
@@ -1,6 +1,8 @@
 package com.example.i_commerce.domain.product.entity;
 
 import com.example.i_commerce.global.common.entity.BaseEntity;
+import com.example.i_commerce.global.error.AppException;
+import com.example.i_commerce.global.error.ErrorCode;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -49,6 +51,9 @@ public class ProductItem extends BaseEntity {
 
     private String displayOptionName;
 
+    @OneToOne(mappedBy = "productItem", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Stock stock;
+
     @ManyToOne
     @JoinColumn(name = "option_value_1_id")
     private ProductOptionValue optionValue1;
@@ -63,10 +68,6 @@ public class ProductItem extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "productItem", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProductAttribute> attributes = new ArrayList<>();
-
-    @Builder.Default
-    @OneToMany(mappedBy = "productItem", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Stock> stocks = new ArrayList<>();
 
 
     public static ProductItem of(
@@ -92,9 +93,11 @@ public class ProductItem extends BaseEntity {
         attribute.setProductItem(this);
     }
 
-    public void addStock(Stock stock) {
-        this.stocks.add(stock);
-        stock.setProductItem(this);
+    public void initStock(Integer quantity) {
+        if(this.stock != null) {
+            throw new AppException(ErrorCode.STOCK_ALREADY_INITIALIZED);
+        }
+        this.stock = Stock.of(this, quantity);
     }
 
     void setProduct(Product product) {

--- a/src/main/java/com/example/i_commerce/domain/product/entity/Stock.java
+++ b/src/main/java/com/example/i_commerce/domain/product/entity/Stock.java
@@ -1,6 +1,8 @@
 package com.example.i_commerce.domain.product.entity;
 
 import com.example.i_commerce.global.common.entity.BaseEntity;
+import com.example.i_commerce.global.error.AppException;
+import com.example.i_commerce.global.error.ErrorCode;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -11,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,8 +35,8 @@ public class Stock extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "product_item_id", nullable = false)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_item_id", nullable = false, unique = true)
     private ProductItem productItem;
 
     @Column(nullable = false)
@@ -46,14 +49,14 @@ public class Stock extends BaseEntity {
     @OneToMany(mappedBy = "stock", cascade = CascadeType.ALL)
     private List<StockHistory> histories = new ArrayList<>();
 
-    public static Stock of(Integer quantity) {
+    public static Stock of(ProductItem item, Integer quantity) {
+        if(quantity < 0) {
+            throw new AppException(ErrorCode.NEGATIVE_QUANTITY_NOT_ALLOWED);
+        }
         return Stock.builder()
+            .productItem(item)
             .quantity(quantity)
             .build();
-    }
-
-    void setProductItem(ProductItem productItem) {
-        this.productItem = productItem;
     }
 
 }

--- a/src/main/java/com/example/i_commerce/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/service/ProductService.java
@@ -102,8 +102,8 @@ public class ProductService {
                 pov1, pov2, itemReq.isDefault()
             );
 
+            productItem.initStock(itemReq.stock());
             addAttribute(productItem, itemReq.attributes(), attributeMap);
-            createStock(productItem, itemReq.stock());
             product.addItem(productItem);
         }
     }
@@ -148,22 +148,7 @@ public class ProductService {
 
     }
 
-    private void createStock(ProductItem productItem, Integer quantity) {
-        Stock stock = Stock.of(quantity);
-        productItem.addStock(stock);
-    }
-
 }
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/src/main/java/com/example/i_commerce/global/error/ErrorCode.java
+++ b/src/main/java/com/example/i_commerce/global/error/ErrorCode.java
@@ -20,6 +20,8 @@ public enum ErrorCode {
 
     // --- Product 도메인 (PRD) ---
     DUPLICATED_SKU(HttpStatus.CONFLICT, "PRD-40901", "SKU는 중복될 수 없습니다."),
+    NEGATIVE_QUANTITY_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "STK-40003", "재고 수량은 음수일 수 없습니다."),
+    STOCK_ALREADY_INITIALIZED(HttpStatus.CONFLICT, "STK-40903", "재고가 이미 초기화되었습니다."),
     INVALID_OPTION(HttpStatus.CONFLICT, "PRD-40902", "요청한 옵션 값이 유효하지 않습니다."),
     EXCEEDED_MAX_OPTION(HttpStatus.CONFLICT, "PRD-40903", "최대 옵션 수를 초과했습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "PRD-40403", "카테고리가 존재하지 않습니다."),

--- a/src/test/java/com/example/i_commerce/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/product/service/ProductServiceTest.java
@@ -202,7 +202,7 @@ public class ProductServiceTest {
             .allMatch(item -> item.getProduct() == product);
 
         assertThat(product.getItems())
-            .allMatch(item -> item.getStocks() != null);
+            .allMatch(item -> item.getStock() != null);
     }
 
 


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
- closed #21 -> develop

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
- 기존에 상품 아이템과 재고가 ManyToOne으로 설정되어 있던 관계를 OneToOne관계로 수정하였습니다.
- 관계 변경에 따라 기존 서비스 클래스, 테스트 코드, 상품 아이템 엔티티, 재고 엔티티 코드에 변경 사항이 생겼습니다.
- 추가로 검증에 필요한 에러 코드가 추가되었습니다.

## ⭐️ Run Test
애플리케이션 정상 작동, 테스트 코드 정상 작동 확인했습니다.

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
- 궁금하신 점, 개선할 부분 편하게 말씀해주세요!