### PR TITLE
feat:리뷰 좋아요 기능 구현(#36)

### DIFF
--- a/src/main/java/com/example/i_commerce/domain/review/controller/ReviewLikeController.java
+++ b/src/main/java/com/example/i_commerce/domain/review/controller/ReviewLikeController.java
@@ -1,0 +1,49 @@
+package com.example.i_commerce.domain.review.controller;
+
+
+import com.example.i_commerce.domain.review.facade.ReviewLikeFacade;
+import com.example.i_commerce.global.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequestMapping("/api/v1/reviews")
+@RequiredArgsConstructor
+public class ReviewLikeController {
+
+    private final ReviewLikeFacade reviewLikeFacade;
+
+    @PostMapping("/{reviewId}/likes")
+    public ResponseEntity<ApiResponse<Boolean>> toggleLike(
+        @PathVariable("reviewId") Long reviewId,
+        @RequestParam("likerId") Long likerId) throws InterruptedException {
+
+        boolean isLiked = reviewLikeFacade.toggleLikeWithRetry(reviewId, likerId);
+        return ResponseEntity.ok(ApiResponse.success(isLiked));
+    }
+
+    @PostMapping("/{reviewId}/best")
+    public ResponseEntity<ApiResponse<Void>> approveBestReview(@PathVariable("reviewId") Long reviewId) {
+        reviewLikeFacade.approveBestReview(reviewId);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @DeleteMapping("/{reviewId}/best")
+    public ResponseEntity<ApiResponse<Void>> cancelBestReview(@PathVariable("reviewId") Long reviewId) {
+        reviewLikeFacade.cancelBestReview(reviewId);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @PostMapping("/{reviewId}/exclude")
+    public ResponseEntity<ApiResponse<Void>> excludeFromBest(@PathVariable("reviewId") Long reviewId) {
+        reviewLikeFacade.excludeFromBest(reviewId);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/domain/review/entity/Review.java
+++ b/src/main/java/com/example/i_commerce/domain/review/entity/Review.java
@@ -1,15 +1,19 @@
 package com.example.i_commerce.domain.review.entity;
 
+import com.example.i_commerce.domain.review.entity.enums.ReviewIsBestStatus;
 import com.example.i_commerce.domain.review.service.dto.CreateReviewRequest;
 import com.example.i_commerce.global.common.entity.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -47,12 +51,20 @@ public class Review extends BaseEntity {
 
     private Long reportCount;
 
-    private Long likeCount;
+    private Long likeCount = 0L;
 
     private Boolean isBest;
 
     private Boolean isUpdated;
 
+    private boolean isExcluded = false;
+
+    @Version
+    private Long version;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    private ReviewIsBestStatus status = ReviewIsBestStatus.NORMAL;
 
     @Builder.Default
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -106,10 +118,6 @@ public class Review extends BaseEntity {
         }
     }
 
-    public void updateBestStatus(boolean isBest) {
-        this.isBest = isBest;
-    }
-
 
     public double calculateRecommendationScore() {
         double score = 0;
@@ -132,6 +140,49 @@ public class Review extends BaseEntity {
         return score;
     }
 
+    public void checkBestEligibility(double threshold) {
+        if (this.isExcluded || this.status == ReviewIsBestStatus.BEST) {
+            return;
+        }
+
+        double currentScore = this.calculateRecommendationScore();
+
+        this.status = (currentScore >= threshold) ? ReviewIsBestStatus.CANDIDATE : ReviewIsBestStatus.NORMAL;
+    }
+
+    public void excludeFromBest() {
+        this.isExcluded = true;
+        this.status = ReviewIsBestStatus.NORMAL;
+        this.isBest = false;
+    }
+
+    public void updateBestStatus(boolean isBest) {
+        this.isBest = isBest;
+        this.status = isBest ? ReviewIsBestStatus.BEST : ReviewIsBestStatus.CANDIDATE;
+    }
+
+    public void approveAsBest() {
+        this.isBest = true;
+        this.status = ReviewIsBestStatus.BEST;
+        this.isExcluded = false;
+    }
+
+    public void cancelBestStatus() {
+        this.isBest = false;
+        this.status = ReviewIsBestStatus.CANDIDATE;
+    }
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+        //updateBestStatus()
+    }
+
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount --;
+            //updateBestStatus()
+        }
+    }
 
     public static Review from(CreateReviewRequest dto) {
         Review review = Review.builder()

--- a/src/main/java/com/example/i_commerce/domain/review/entity/Review.java
+++ b/src/main/java/com/example/i_commerce/domain/review/entity/Review.java
@@ -174,13 +174,13 @@ public class Review extends BaseEntity {
 
     public void increaseLikeCount() {
         this.likeCount++;
-        //updateBestStatus()
+        this.calculateRecommendationScore();
     }
 
     public void decreaseLikeCount() {
         if (this.likeCount > 0) {
             this.likeCount --;
-            //updateBestStatus()
+            this.calculateRecommendationScore();
         }
     }
 

--- a/src/main/java/com/example/i_commerce/domain/review/entity/ReviewComment.java
+++ b/src/main/java/com/example/i_commerce/domain/review/entity/ReviewComment.java
@@ -33,8 +33,6 @@ public class ReviewComment extends BaseEntity {
     @JoinColumn(name = "review_id", nullable = false)
     private Review review;
 
-//    @Column(nullable = false)
-//    private Long reviewId;
 
     @Column(nullable = false, length = 50)
     private Long sellerId;

--- a/src/main/java/com/example/i_commerce/domain/review/entity/ReviewImage.java
+++ b/src/main/java/com/example/i_commerce/domain/review/entity/ReviewImage.java
@@ -32,9 +32,6 @@ public class ReviewImage extends BaseEntity {
     @JoinColumn(name = "review_id", nullable = false)
     private Review review;
 
-//    @Column(nullable = false)
-//    private Long reviewId;
-
     @Column(columnDefinition = "TEXT")
     private String imageUrl;
 

--- a/src/main/java/com/example/i_commerce/domain/review/entity/ReviewLike.java
+++ b/src/main/java/com/example/i_commerce/domain/review/entity/ReviewLike.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,7 +17,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "review_likes")
+@Table(
+    name = "review_likes",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_member_review", // 제약 조건 이름
+            columnNames = {"member_id", "review_id"} // 중복을 허용하지 않을 컬럼 조합
+        )
+    }
+)
 @Getter
 @Builder
 @AllArgsConstructor
@@ -31,7 +40,7 @@ public class ReviewLike {
     @JoinColumn(name = "review_id", nullable = false)
     private Review review;
 
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false)
     private Long likerId;
 
 }

--- a/src/main/java/com/example/i_commerce/domain/review/entity/ReviewLike.java
+++ b/src/main/java/com/example/i_commerce/domain/review/entity/ReviewLike.java
@@ -31,9 +31,7 @@ public class ReviewLike {
     @JoinColumn(name = "review_id", nullable = false)
     private Review review;
 
-//    @Column(nullable = false)
-//    private Long reviewId;
-
     @Column(nullable = false, length = 50)
-    private String likerId;
+    private Long likerId;
+
 }

--- a/src/main/java/com/example/i_commerce/domain/review/entity/ReviewReport.java
+++ b/src/main/java/com/example/i_commerce/domain/review/entity/ReviewReport.java
@@ -34,9 +34,6 @@ public class ReviewReport {
     @JoinColumn(name = "review_id", nullable = false)
     private Review review;
 
-//    @Column(nullable = false)
-//    private Long reviewId;
-
     @Column(nullable = false, length = 50)
     private Long reporterId;
 

--- a/src/main/java/com/example/i_commerce/domain/review/entity/enums/ReviewIsBestStatus.java
+++ b/src/main/java/com/example/i_commerce/domain/review/entity/enums/ReviewIsBestStatus.java
@@ -1,0 +1,7 @@
+package com.example.i_commerce.domain.review.entity.enums;
+
+public enum ReviewIsBestStatus {
+    NORMAL,
+    CANDIDATE,
+    BEST;
+}

--- a/src/main/java/com/example/i_commerce/domain/review/facade/ReviewLikeFacade.java
+++ b/src/main/java/com/example/i_commerce/domain/review/facade/ReviewLikeFacade.java
@@ -1,0 +1,37 @@
+package com.example.i_commerce.domain.review.facade;
+
+import com.example.i_commerce.domain.review.service.ReviewLikeService;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ReviewLikeFacade {
+
+    private final ReviewLikeService reviewLikeService;
+
+    // 1. 재시도 로직이 필요한 좋아요 기능
+    public boolean toggleLikeWithRetry(Long reviewId, Long likerId) throws InterruptedException {
+        while (true) {
+            try {
+                return reviewLikeService.toggleLike(reviewId, likerId);
+            } catch (ObjectOptimisticLockingFailureException e) {
+                Thread.sleep(50);
+            }
+        }
+    }
+
+    // 2. 단순 전달 (판매자 권한 기능들)
+    public void approveBestReview(Long reviewId) {
+        reviewLikeService.approveBestReview(reviewId);
+    }
+
+    public void cancelBestReview(Long reviewId) {
+        reviewLikeService.cancelBestReview(reviewId);
+    }
+
+    public void excludeFromBest(Long reviewId) {
+        reviewLikeService.excludeReviewFromBest(reviewId);
+    }
+}

--- a/src/main/java/com/example/i_commerce/domain/review/repo/ReviewLikeRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/review/repo/ReviewLikeRepository.java
@@ -7,13 +7,16 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select r from Review r where r.id = :id")
-    Optional<ReviewLike> findByReviewAndLikerId(Review review, Long likerId);
+    @Query("select rl from ReviewLike rl where rl.review = :review and rl.likerId = :likerId")
+    Optional<ReviewLike> findByReviewAndLikerId(
+        @Param("review") Review review,
+        @Param("likerId") Long likerId);
 
 }

--- a/src/main/java/com/example/i_commerce/domain/review/repo/ReviewLikeRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/review/repo/ReviewLikeRepository.java
@@ -1,0 +1,19 @@
+package com.example.i_commerce.domain.review.repo;
+
+import com.example.i_commerce.domain.review.entity.Review;
+import com.example.i_commerce.domain.review.entity.ReviewLike;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select r from Review r where r.id = :id")
+    Optional<ReviewLike> findByReviewAndLikerId(Review review, Long likerId);
+
+}

--- a/src/main/java/com/example/i_commerce/domain/review/service/ReviewLikeService.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/ReviewLikeService.java
@@ -1,0 +1,75 @@
+package com.example.i_commerce.domain.review.service;
+
+import com.example.i_commerce.domain.review.entity.Review;
+import com.example.i_commerce.domain.review.entity.ReviewLike;
+import com.example.i_commerce.domain.review.exception.ReviewErrorCode;
+import com.example.i_commerce.domain.review.repo.ReviewLikeRepository;
+import com.example.i_commerce.domain.review.repo.ReviewRepository;
+import com.example.i_commerce.global.exception.AppException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReviewLikeService {
+
+    private final ReviewRepository reviewRepo;
+    private final ReviewLikeRepository reviewLikeRepo;
+    private static final double BEST_THRESHOLD = 80.0;
+
+    @Transactional
+    public boolean toggleLike(Long reviewId, Long likerId) {
+
+        Review review = getReviewOrThrow(reviewId);
+
+        Optional<ReviewLike> existingLike = reviewLikeRepo.findByReviewAndLikerId(review, likerId);
+
+        boolean isLiked;
+
+        if (existingLike.isPresent()) {
+            reviewLikeRepo.delete(existingLike.get());
+            review.decreaseLikeCount();
+            isLiked = false;
+        } else {
+            ReviewLike newLike = ReviewLike.builder()
+                .review(review)
+                .likerId(likerId)
+                .build();
+            reviewLikeRepo.save(newLike);
+            review.increaseLikeCount();
+            isLiked = true;
+        }
+
+        review.checkBestEligibility(BEST_THRESHOLD);
+        return isLiked;
+
+    }
+
+    @Transactional
+    public void approveBestReview(Long reviewId) {
+        Review review = getReviewOrThrow(reviewId);
+        review.approveAsBest();
+    }
+
+    @Transactional
+    public void cancelBestReview(Long reviewId) {
+        Review review = getReviewOrThrow(reviewId);
+        review.cancelBestStatus();
+    }
+
+    @Transactional
+    public void excludeReviewFromBest(Long reviewId) {
+        Review review = getReviewOrThrow(reviewId);
+        review.excludeFromBest();
+    }
+
+    private Review getReviewOrThrow(Long reviewId) {
+        return reviewRepo.findById(reviewId)
+            .orElseThrow(() -> new AppException(ReviewErrorCode.REVIEW_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/i_commerce/global/security/config/SecurityConfig.java
@@ -19,7 +19,8 @@ public class SecurityConfig {
                 // 전체 공개 API
                 .requestMatchers(
                     "/api/products/**",
-                    "/api/categories/**"
+                    "/api/categories/**",
+                    "/api/v1/reviews/**"
                 ).permitAll()
 
                 // 로그인 / 회원가입도 보통 공개

--- a/src/test/java/com/example/i_commerce/domain/review/facade/ReviewLikeFacadeTest.java
+++ b/src/test/java/com/example/i_commerce/domain/review/facade/ReviewLikeFacadeTest.java
@@ -1,0 +1,48 @@
+package com.example.i_commerce.domain.review.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.example.i_commerce.domain.review.entity.Review;
+import com.example.i_commerce.domain.review.facade.ReviewLikeFacade;
+import com.example.i_commerce.domain.review.service.ReviewLikeService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
+@ExtendWith(MockitoExtension.class)
+public class ReviewLikeFacadeTest {
+
+    @Mock
+    private ReviewLikeService reviewLikeService;
+
+    @InjectMocks
+    private ReviewLikeFacade reviewLikeFacade;
+
+    @Test
+    @DisplayName("낙관적 락 충돌이 발생하면 성공할 때까지 재시도한다")
+    void toggleLike_RetryOnConflict() throws InterruptedException {
+        //given
+        Long reviewId = 1L;
+        Long likerId = 100L;
+
+        given(reviewLikeService.toggleLike(reviewId, likerId))
+            .willThrow(new ObjectOptimisticLockingFailureException(Review.class, "conflict"))
+            .willThrow(new ObjectOptimisticLockingFailureException(Review.class, "conflict"))
+            .willReturn(true);
+
+        //when
+        boolean result = reviewLikeFacade.toggleLikeWithRetry(reviewId, likerId);
+
+        //then
+        assertThat(result).isTrue();
+        verify(reviewLikeService, times(3)).toggleLike(reviewId, likerId);
+    }
+
+}

--- a/src/test/java/com/example/i_commerce/domain/review/repository/ReviewLikeRepositoryTest.java
+++ b/src/test/java/com/example/i_commerce/domain/review/repository/ReviewLikeRepositoryTest.java
@@ -1,0 +1,57 @@
+package com.example.i_commerce.domain.review.repository;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.i_commerce.domain.review.entity.Review;
+import com.example.i_commerce.domain.review.entity.ReviewLike;
+import com.example.i_commerce.domain.review.entity.enums.ReviewIsBestStatus;
+import com.example.i_commerce.domain.review.repo.ReviewLikeRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // 실제 DB(PostgreSQL)를 사용하거나 H2를 선택할 수 있어요.
+class ReviewLikeRepositoryTest {
+
+    @Autowired
+    private ReviewLikeRepository reviewLikeRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    @DisplayName("리뷰와 사용자 ID로 좋아요 기록을 정확히 조회한다")
+    void findByReviewAndLikerId_Success() {
+        // given
+        Review review = Review.builder()
+            .orderProductId(1L)
+            .userId(1L)
+            .content("정말 좋아유")
+            .starRate(5)
+            .likeCount(0L)
+            .status(ReviewIsBestStatus.NORMAL)
+            .isExcluded(false)
+            .build();
+        entityManager.persist(review);
+
+        ReviewLike like = ReviewLike.builder()
+            .review(review)
+            .likerId(28L)
+            .build();
+        entityManager.persist(like);
+        entityManager.flush();
+
+        // when
+        Optional<ReviewLike> result = reviewLikeRepository.findByReviewAndLikerId(review, 28L);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getLikerId()).isEqualTo(28L);
+    }
+}

--- a/src/test/java/com/example/i_commerce/domain/review/service/ReviewLikeServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/review/service/ReviewLikeServiceTest.java
@@ -1,7 +1,6 @@
 package com.example.i_commerce.domain.review.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.given;
 
 import com.example.i_commerce.domain.review.entity.Review;
 import com.example.i_commerce.domain.review.entity.enums.ReviewIsBestStatus;

--- a/src/test/java/com/example/i_commerce/domain/review/service/ReviewLikeServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/review/service/ReviewLikeServiceTest.java
@@ -1,0 +1,110 @@
+package com.example.i_commerce.domain.review.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.given;
+
+import com.example.i_commerce.domain.review.entity.Review;
+import com.example.i_commerce.domain.review.entity.enums.ReviewIsBestStatus;
+import com.example.i_commerce.domain.review.repo.ReviewLikeRepository;
+import com.example.i_commerce.domain.review.repo.ReviewRepository;
+import com.example.i_commerce.domain.review.service.ReviewLikeService;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class ReviewLikeServiceTest {
+
+    @Mock
+    private ReviewRepository reviewRepo;
+
+    @Mock
+    private ReviewLikeRepository reviewLikeRepo;
+
+    @InjectMocks
+    private ReviewLikeService reviewLikeService;
+
+    private Review review;
+    private final Long reviewId = 1L;
+    private final Long likerId = 100L;
+    private final double THRESHOLD = 80.0;
+
+    @BeforeEach
+    void setUp() {
+        review = Review.builder()
+            .id(reviewId)
+            .content("정말 좋아유")
+            .starRate(5)
+            .likeCount(0L)
+            .status(ReviewIsBestStatus.NORMAL)
+            .isExcluded(false)
+            .build();
+    }
+
+    @Test
+    @DisplayName("판매자는 점수와 상관없이 어떤 리뷰든 BEST로 지정할 수 있다.")
+    void approveBestReview_ForceSuccess() {
+        //given
+        given(reviewRepo.findById(reviewId)).willReturn(Optional.of(review));
+
+        //when
+        reviewLikeService.approveBestReview(reviewId);
+
+        //then
+        assertThat(review.getStatus()).isEqualTo(ReviewIsBestStatus.BEST);
+        assertThat(review.getIsBest()).isTrue();
+    }
+
+    @Test
+    @DisplayName("후보에서 제외 처리된 리뷰는 좋아요가 눌려도 CANDIDATE로 변경되지 않는다.")
+    void toggleLike_OnExcludeReview_RemainNormal() {
+        //given
+        review.excludeFromBest();
+        given(reviewRepo.findById(reviewId)).willReturn(Optional.of(review));
+        given(reviewLikeRepo.findByReviewAndLikerId(review, likerId)).willReturn(Optional.empty());
+
+        //when
+        reviewLikeService.toggleLike(reviewId, likerId);
+
+        //then
+        assertThat(review.getLikeCount()).isEqualTo(1L);
+        assertThat(review.isExcluded()).isTrue();
+        assertThat(review.getStatus()).isEqualTo(ReviewIsBestStatus.NORMAL);
+    }
+
+    @Test
+    @DisplayName("베스트 리뷰를 취소하면 다시 점수에 따라 상태가 재결정된다")
+    void cancelBestReview_AndReEvaluate() {
+        //given
+        review.approveAsBest();
+        given(reviewRepo.findById(reviewId)).willReturn(Optional.of(review));
+
+        //when
+        reviewLikeService.cancelBestReview(reviewId);
+
+        //then
+        assertThat(review.getStatus()).isEqualTo(ReviewIsBestStatus.CANDIDATE);
+        assertThat(review.getIsBest()).isFalse();
+    }
+
+    @Test
+    @DisplayName("특정 리뷰를 베스트 후보에서 제외하면 즉시 NORMAL 상태로 강등된다")
+    void excludeReview_ImmediatelyDowngrade() {
+        // given
+        review.checkBestEligibility(80.0); // 만약 점수가 높아 후보(CANDIDATE)인 상태였다면
+        given(reviewRepo.findById(reviewId)).willReturn(Optional.of(review));
+
+        // when
+        reviewLikeService.excludeReviewFromBest(reviewId);
+
+        // then
+        assertThat(review.isExcluded()).isTrue();
+        assertThat(review.getStatus()).isEqualTo(ReviewIsBestStatus.NORMAL);
+    }
+}

--- a/src/test/java/com/example/i_commerce/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/review/service/ReviewServiceTest.java
@@ -1,4 +1,4 @@
-package com.example.i_commerce.review.service;
+package com.example.i_commerce.domain.review.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;


### PR DESCRIPTION
## 🛠 Related issue
closed #36 

## ✏️ Work Description
리뷰 좋아요와 관련된 기능들을 구현했습니다.
- 리뷰 좋아요 토글 기능 구현(좋아요 추가 / 취소)
- 동시성 제어(@Version 낙관락 적용)
- 재시도 로직(낙관락 충돌 시 재시도를 위해 Facade 사용)
- DB 중복 방지(liker_id, review_id 복합 유니크 키 설정)    

## 📢 To Reviewers
개선해야 할 부분 말씀해 주시면 감사하겠습니다!

