### PR TITLE
Feat: 카테고리 조회 API

### DIFF
--- a/src/main/java/com/example/i_commerce/domain/product/application/mapper/CategoryMapper.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/mapper/CategoryMapper.java
@@ -32,6 +32,19 @@ public class CategoryMapper {
             .toList();
     }
 
+    public CategoryResponse toTree(List<CategoryTreeRow> rows) {
+
+        Map<Long, List<CategoryTreeRow>> childrenByParentId = rows.stream()
+            .filter(row -> row.getParentId() != null)
+            .collect(Collectors.groupingBy(
+                CategoryTreeRow::getParentId,
+                LinkedHashMap::new,
+                Collectors.toList()
+            ));
+
+        return buildNode(rows.getFirst(), childrenByParentId);
+    }
+
     private CategoryResponse buildNode(
         CategoryTreeRow row,
         Map<Long, List<CategoryTreeRow>> childrenByParentId

--- a/src/main/java/com/example/i_commerce/domain/product/application/mapper/CategoryMapper.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/mapper/CategoryMapper.java
@@ -18,31 +18,31 @@ public class CategoryMapper {
             return Collections.emptyList();
         }
 
-        Map<Long, List<CategoryTreeRow>> childrenByParentId = rows.stream()
-            .filter(row -> row.getParentId() != null)
-            .collect(Collectors.groupingBy(
-                CategoryTreeRow::getParentId,
-                LinkedHashMap::new,
-                Collectors.toList()
-            ));
+        Map<Long, List<CategoryTreeRow>> childrenMap = groupByParentId(rows);
 
         return rows.stream()
             .filter(row -> row.getParentId() == null)
-            .map(root -> buildNode(root, childrenByParentId))
+            .map(root -> buildNode(root, childrenMap))
             .toList();
     }
 
     public CategoryResponse toTree(List<CategoryTreeRow> rows) {
 
-        Map<Long, List<CategoryTreeRow>> childrenByParentId = rows.stream()
+        Map<Long, List<CategoryTreeRow>> childrenMap = groupByParentId(rows);
+
+        return buildNode(rows.getFirst(), childrenMap);
+    }
+
+    private Map<Long, List<CategoryTreeRow>> groupByParentId(
+        List<CategoryTreeRow> rows
+    ) {
+        return rows.stream()
             .filter(row -> row.getParentId() != null)
             .collect(Collectors.groupingBy(
                 CategoryTreeRow::getParentId,
                 LinkedHashMap::new,
                 Collectors.toList()
             ));
-
-        return buildNode(rows.getFirst(), childrenByParentId);
     }
 
     private CategoryResponse buildNode(

--- a/src/main/java/com/example/i_commerce/domain/product/application/mapper/CategoryMapper.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/mapper/CategoryMapper.java
@@ -1,0 +1,54 @@
+package com.example.i_commerce.domain.product.application.mapper;
+
+
+import com.example.i_commerce.domain.product.controller.response.CategoryResponse;
+import com.example.i_commerce.domain.product.repository.projection.CategoryTreeRow;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CategoryMapper {
+
+    public List<CategoryResponse> toHierarchy(List<CategoryTreeRow> rows) {
+        if (rows == null || rows.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Map<Long, List<CategoryTreeRow>> childrenByParentId = rows.stream()
+            .filter(row -> row.getParentId() != null)
+            .collect(Collectors.groupingBy(
+                CategoryTreeRow::getParentId,
+                LinkedHashMap::new,
+                Collectors.toList()
+            ));
+
+        return rows.stream()
+            .filter(row -> row.getParentId() == null)
+            .map(root -> buildNode(root, childrenByParentId))
+            .toList();
+    }
+
+    private CategoryResponse buildNode(
+        CategoryTreeRow row,
+        Map<Long, List<CategoryTreeRow>> childrenByParentId
+    ) {
+        List<CategoryResponse> children = childrenByParentId
+            .getOrDefault(row.getId(), Collections.emptyList())
+            .stream()
+            .map(child -> buildNode(child, childrenByParentId))
+            .toList();
+
+        return CategoryResponse.builder()
+            .id(row.getId())
+            .parentId(row.getParentId())
+            .name(row.getName())
+            .depth(row.getDepth())
+            .children(children)
+            .build();
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryService.java
@@ -39,7 +39,7 @@ public class CategoryService {
         List<CategoryTreeRow> rows =
             categoryRepository.findCategoryTreeById(id, DEFAULT_TREE_DEPTH);
 
-        if(rows == null || rows.isEmpty()) {
+        if (rows.isEmpty()) {
             throw new AppException(ProductErrorCode.CATEGORY_NOT_FOUND);
         }
 

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryService.java
@@ -1,0 +1,36 @@
+package com.example.i_commerce.domain.product.application.service;
+
+
+import com.example.i_commerce.domain.product.application.mapper.CategoryMapper;
+import com.example.i_commerce.domain.product.repository.projection.CategoryTreeRow;
+import com.example.i_commerce.domain.product.controller.response.CategoryResponse;
+import com.example.i_commerce.domain.product.repository.CategoryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private static final int DEFAULT_TREE_DEPTH = 3;
+    private static final int RECURSIVE_DEPTH_LIMIT = 5;
+
+    private final CategoryRepository categoryRepository;
+    private final CategoryMapper categoryMapper;
+
+    @Transactional(readOnly = true)
+    public List<CategoryResponse> getAllCategories(Integer requestDepth) {
+
+        int maxDepth = (requestDepth == null)
+            ? DEFAULT_TREE_DEPTH
+            : Math.min(requestDepth, RECURSIVE_DEPTH_LIMIT);
+
+        List<CategoryTreeRow> rows = categoryRepository.findAllCategoryTree(maxDepth);
+
+        return categoryMapper.toHierarchy(rows);
+    }
+
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryService.java
@@ -2,9 +2,11 @@ package com.example.i_commerce.domain.product.application.service;
 
 
 import com.example.i_commerce.domain.product.application.mapper.CategoryMapper;
+import com.example.i_commerce.domain.product.exception.ProductErrorCode;
 import com.example.i_commerce.domain.product.repository.projection.CategoryTreeRow;
 import com.example.i_commerce.domain.product.controller.response.CategoryResponse;
 import com.example.i_commerce.domain.product.repository.CategoryRepository;
+import com.example.i_commerce.global.exception.AppException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,6 +32,18 @@ public class CategoryService {
         List<CategoryTreeRow> rows = categoryRepository.findAllCategoryTree(maxDepth);
 
         return categoryMapper.toHierarchy(rows);
+    }
+
+    @Transactional(readOnly = true)
+    public CategoryResponse getCategoryById(Long id) {
+        List<CategoryTreeRow> rows =
+            categoryRepository.findCategoryTreeById(id, DEFAULT_TREE_DEPTH);
+
+        if(rows == null || rows.isEmpty()) {
+            throw new AppException(ProductErrorCode.CATEGORY_NOT_FOUND);
+        }
+
+        return categoryMapper.toTree(rows);
     }
 
 

--- a/src/main/java/com/example/i_commerce/domain/product/controller/CategoryController.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/CategoryController.java
@@ -1,0 +1,29 @@
+package com.example.i_commerce.domain.product.controller;
+
+
+import com.example.i_commerce.domain.product.application.service.CategoryService;
+import com.example.i_commerce.domain.product.controller.response.CategoryResponse;
+import com.example.i_commerce.global.common.response.ApiResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/categories")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping
+    public ApiResponse<List<CategoryResponse>> getAllCategories(
+        @RequestParam(required = false) Integer maxDepth
+    ) {
+        return ApiResponse.success(categoryService.getAllCategories(maxDepth));
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/controller/CategoryController.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/CategoryController.java
@@ -7,6 +7,7 @@ import com.example.i_commerce.global.common.response.ApiResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,6 +25,13 @@ public class CategoryController {
         @RequestParam(required = false) Integer maxDepth
     ) {
         return ApiResponse.success(categoryService.getAllCategories(maxDepth));
+    }
+
+    @GetMapping("/{categoryId}")
+    public ApiResponse<CategoryResponse> getCategories(
+        @PathVariable Long categoryId
+    ) {
+        return ApiResponse.success(categoryService.getCategoryById(categoryId));
     }
 
 }

--- a/src/main/java/com/example/i_commerce/domain/product/controller/request/CreateProductRequest.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/request/CreateProductRequest.java
@@ -1,7 +1,5 @@
 package com.example.i_commerce.domain.product.controller.request;
 
-
-import com.example.i_commerce.domain.product.entity.OptionType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import com.example.i_commerce.domain.product.entity.ProductOptionType;
 import jakarta.validation.constraints.Max;

--- a/src/main/java/com/example/i_commerce/domain/product/controller/response/CategoryResponse.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/response/CategoryResponse.java
@@ -1,0 +1,16 @@
+package com.example.i_commerce.domain.product.controller.response;
+
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record CategoryResponse(
+    Long id,
+    Long parentId,
+    String name,
+    Integer depth,
+    List<CategoryResponse> children
+) {
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/repository/CategoryRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/CategoryRepository.java
@@ -1,5 +1,6 @@
 package com.example.i_commerce.domain.product.repository;
 
+import com.example.i_commerce.domain.product.repository.projection.CategoryTreeRow;
 import com.example.i_commerce.domain.product.entity.Category;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +10,25 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    @Query(value = """
+        WITH RECURSIVE category_tree AS (
+            SELECT id, parent_id, name, depth, 0 AS relative_depth
+            FROM categories
+            WHERE parent_id IS NULL
+
+            UNION ALL
+
+            SELECT c.id, c.parent_id, c.name, c.depth, ct.relative_depth + 1
+            FROM categories c
+            INNER JOIN category_tree ct ON c.parent_id = ct.id
+            WHERE ct.relative_depth < :maxDepth
+        )
+        SELECT id, parent_id, name, depth
+        FROM category_tree
+        ORDER BY depth, id
+        """, nativeQuery = true)
+    List<CategoryTreeRow> findAllCategoryTree(@Param("maxDepth") int maxDepth);
 
     @Query(value = """
         WITH RECURSIVE category_tree AS (

--- a/src/main/java/com/example/i_commerce/domain/product/repository/CategoryRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/CategoryRepository.java
@@ -32,6 +32,28 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     @Query(value = """
         WITH RECURSIVE category_tree AS (
+            SELECT id, parent_id, name, depth, 0 AS relative_depth
+            FROM categories
+            WHERE id = :rootId
+
+            UNION ALL
+
+            SELECT c.id, c.parent_id, c.name, c.depth, ct.relative_depth + 1
+            FROM categories c
+            INNER JOIN category_tree ct ON c.parent_id = ct.id
+            WHERE ct.relative_depth < :maxDepth
+        )
+        SELECT id, parent_id, name, depth
+        FROM category_tree
+        ORDER BY depth, id
+        """, nativeQuery = true)
+    List<CategoryTreeRow> findCategoryTreeById(
+        @Param("rootId") Long rootId,
+        @Param("maxDepth") int maxDepth
+    );
+
+    @Query(value = """
+        WITH RECURSIVE category_tree AS (
             SELECT id, 0 AS depth
             FROM categories
             WHERE id = :categoryId

--- a/src/main/java/com/example/i_commerce/domain/product/repository/projection/CategoryTreeRow.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/projection/CategoryTreeRow.java
@@ -1,0 +1,8 @@
+package com.example.i_commerce.domain.product.repository.projection;
+
+public interface CategoryTreeRow {
+    Long getId();
+    Long getParentId();
+    String getName();
+    Integer getDepth();
+}


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
- closed #50 -> develop

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
카테고리 조회 기능을 개발했습니다. 다음 두가지 조회가 가능합니다.
- 전체 카테고리 조회 (depth 제한 있음)
- 선택된 카테고리 조회, 기본 depth만큼 자식들도 같이 조회됨

쿼리 응답을 계층 구조 응답으로 변환하기 위한 mapper가 포함됩니다.

## ⭐️ Run Test
[//]: # (없다면 N/A)
postman으로 정상적으로 조회됨을 확인했습니다.
<details>
  <summary>전체 카테고리 조회</summary>

<img width="981" height="453" alt="image" src="https://github.com/user-attachments/assets/f6c9c84a-4acd-408a-b465-349eae12f7d3" />

</details>


## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
- 궁금하신 점, 개선 필요한 부분 등 편하게 의견 주세요!!

