### PR TITLE
Feat: 장바구니 상품 추가 API

### DIFF
--- a/src/main/java/com/example/i_commerce/domain/cart/controller/CartController.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/controller/CartController.java
@@ -1,0 +1,33 @@
+package com.example.i_commerce.domain.cart.controller;
+
+
+import com.example.i_commerce.domain.cart.controller.request.AddCartItemRequest;
+import com.example.i_commerce.domain.cart.controller.response.AddCartItemResponse;
+import com.example.i_commerce.domain.cart.service.CartService;
+import com.example.i_commerce.global.common.response.ApiResponse;
+import com.example.i_commerce.global.security.principal.CustomUserPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/carts")
+public class CartController {
+
+    private final CartService cartService;
+
+    @PostMapping("/items")
+    public ApiResponse<AddCartItemResponse> addCartItem(
+        @AuthenticationPrincipal CustomUserPrincipal principal,
+        @RequestBody @Valid AddCartItemRequest request
+    ) {
+        AddCartItemResponse response = cartService.addCartItem(principal.getId(), request);
+        return ApiResponse.success(response);
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/domain/cart/controller/request/AddCartItemRequest.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/controller/request/AddCartItemRequest.java
@@ -1,0 +1,14 @@
+package com.example.i_commerce.domain.cart.controller.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record AddCartItemRequest(
+    @NotNull
+    Long productItemId,
+
+    @Min(1)
+    Integer quantity
+
+) {
+}

--- a/src/main/java/com/example/i_commerce/domain/cart/controller/request/AddCartItemRequest.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/controller/request/AddCartItemRequest.java
@@ -7,6 +7,7 @@ public record AddCartItemRequest(
     @NotNull
     Long productItemId,
 
+    @NotNull
     @Min(1)
     Integer quantity
 

--- a/src/main/java/com/example/i_commerce/domain/cart/controller/response/AddCartItemResponse.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/controller/response/AddCartItemResponse.java
@@ -1,0 +1,28 @@
+package com.example.i_commerce.domain.cart.controller.response;
+
+import com.example.i_commerce.domain.cart.entity.CartItem;
+import lombok.Builder;
+
+@Builder
+public record AddCartItemResponse(
+    Long cartItemId,
+    Long productItemId,
+    String productName,
+    Integer price,
+    String displayOptionName,
+    Integer quantity,
+    Boolean isChecked
+) {
+    public static AddCartItemResponse from(CartItem cartItem) {
+        return AddCartItemResponse.builder()
+            .cartItemId(cartItem.getId())
+            .productItemId(cartItem.getProductItemId())
+            .productName(cartItem.getProductName())
+            .price(cartItem.getPrice())
+            .displayOptionName(cartItem.getDisplayOptionName())
+            .quantity(cartItem.getQuantity())
+            .isChecked(cartItem.getIsChecked())
+            .build();
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/domain/cart/entity/Cart.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/entity/Cart.java
@@ -1,6 +1,7 @@
 package com.example.i_commerce.domain.cart.entity;
 
 import com.example.i_commerce.global.common.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -10,6 +11,8 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,10 +36,22 @@ public class Cart extends BaseEntity {
 
     private String guestToken;
 
-    private String userId;
+    private Long userId;
 
     @Builder.Default
-    @OneToMany(mappedBy = "cart")
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CartItem> cartItems = new ArrayList<>();
+
+    public static Cart create(Long userId) {
+        return Cart.builder()
+            .userId(userId)
+            .build();
+    }
+
+    public Optional<CartItem> findCartItem(Long productId) {
+        return cartItems.stream()
+            .filter(item -> Objects.equals(item.getProductItemId(), productId))
+            .findFirst();
+    }
 
 }

--- a/src/main/java/com/example/i_commerce/domain/cart/entity/Cart.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/entity/Cart.java
@@ -54,4 +54,8 @@ public class Cart extends BaseEntity {
             .findFirst();
     }
 
+    public void addItem(CartItem item) {
+        this.cartItems.add(item);
+    }
+
 }

--- a/src/main/java/com/example/i_commerce/domain/cart/entity/Cart.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/entity/Cart.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -16,7 +17,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "carts")
+@Table(
+    name = "carts",
+    uniqueConstraints = @UniqueConstraint(columnNames = "user_id")
+)
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/com/example/i_commerce/domain/cart/entity/CartItem.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/entity/CartItem.java
@@ -51,6 +51,25 @@ public class CartItem extends BaseEntity {
     @Builder.Default
     private Boolean isChecked = true;
 
+
+    public static CartItem of(
+        Cart cart,
+        Long productItemId,
+        String productName,
+        Integer price,
+        String displayOptionName,
+        Integer quantity
+    ) {
+        return CartItem.builder()
+            .cart(cart)
+            .productItemId(productItemId)
+            .productName(productName)
+            .price(price)
+            .displayOptionName(displayOptionName)
+            .quantity(quantity)
+            .build();
+    }
+
     public void increaseQuantity(int amount, int stockQuantity) {
         int newQuantity = this.quantity + amount;
         if (newQuantity > stockQuantity) {

--- a/src/main/java/com/example/i_commerce/domain/cart/entity/CartItem.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/entity/CartItem.java
@@ -1,6 +1,8 @@
 package com.example.i_commerce.domain.cart.entity;
 
+import com.example.i_commerce.domain.cart.exception.CartErrorCode;
 import com.example.i_commerce.global.common.entity.BaseEntity;
+import com.example.i_commerce.global.exception.AppException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -48,5 +50,13 @@ public class CartItem extends BaseEntity {
 
     @Builder.Default
     private Boolean isChecked = true;
+
+    public void increaseQuantity(int amount, int stockQuantity) {
+        int newQuantity = this.quantity + amount;
+        if (newQuantity > stockQuantity) {
+            throw new AppException(CartErrorCode.EXCEED_STOCK_QUANTITY);
+        }
+        this.quantity = newQuantity;
+    }
 
 }

--- a/src/main/java/com/example/i_commerce/domain/cart/entity/CartItem.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/entity/CartItem.java
@@ -33,7 +33,15 @@ public class CartItem extends BaseEntity {
     private Cart cart;
 
     @Column(nullable = false)
-    private Long productItem;
+    private Long productItemId;
+
+    @Column(nullable = false)
+    private String productName;
+
+    @Column(nullable = false)
+    private Integer price;
+
+    private String displayOptionName;
 
     @Column(nullable = false)
     private Integer quantity;

--- a/src/main/java/com/example/i_commerce/domain/cart/exception/CartErrorCode.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/exception/CartErrorCode.java
@@ -1,0 +1,20 @@
+package com.example.i_commerce.domain.cart.exception;
+
+import com.example.i_commerce.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CartErrorCode implements ErrorCode {
+
+    EXCEED_STOCK_QUANTITY(HttpStatus.CONFLICT, "CRT-40901", "재고를 초과했습니다."),
+    PRODUCT_NOT_AVAILABLE(HttpStatus.CONFLICT, "CRT-40902", "사용할 수 없는 상품입니다."),
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/i_commerce/domain/cart/infrastructure/ProductClient.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/infrastructure/ProductClient.java
@@ -1,0 +1,28 @@
+package com.example.i_commerce.domain.cart.infrastructure;
+
+
+import com.example.i_commerce.domain.product.facade.ProductQueryFacade;
+import com.example.i_commerce.domain.product.facade.dto.ProductItemInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProductClient {
+
+    private final ProductQueryFacade productQueryFacade;
+
+    public ProductItemInfo getProductItem(Long productItemId) {
+        ProductItemInfoResponse res = productQueryFacade.getProductItemInfo(productItemId);
+
+        return ProductItemInfo.builder()
+            .productItemId(res.productItemId())
+            .productName(res.productName())
+            .price(res.price())
+            .displayOptionName(res.displayOptionName())
+            .stockQuantity(res.stockQuantity())
+            .isAvailable(res.onSale())
+            .build();
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/domain/cart/infrastructure/ProductItemInfo.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/infrastructure/ProductItemInfo.java
@@ -1,0 +1,16 @@
+package com.example.i_commerce.domain.cart.infrastructure;
+
+
+import lombok.Builder;
+
+@Builder
+public record ProductItemInfo(
+    Long productItemId,
+    String productName,
+    Integer price,
+    String displayOptionName,
+    Integer stockQuantity,
+    boolean isAvailable
+) {
+
+}

--- a/src/main/java/com/example/i_commerce/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/repository/CartItemRepository.java
@@ -1,0 +1,10 @@
+package com.example.i_commerce.domain.cart.repository;
+
+import com.example.i_commerce.domain.cart.entity.CartItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+
+}

--- a/src/main/java/com/example/i_commerce/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/repository/CartRepository.java
@@ -1,0 +1,19 @@
+package com.example.i_commerce.domain.cart.repository;
+
+import com.example.i_commerce.domain.cart.entity.Cart;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CartRepository extends JpaRepository<Cart, Long> {
+
+    @Query("""
+        SELECT c
+        FROM Cart c
+        LEFT JOIN FETCH c.cartItems
+        WHERE c.userId = :userId
+    """)
+    Optional<Cart> findByUserIdWithItems(Long userId);
+}

--- a/src/main/java/com/example/i_commerce/domain/cart/service/CartService.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/service/CartService.java
@@ -50,6 +50,7 @@ public class CartService {
                     productItemInfo.displayOptionName(),
                     request.quantity()
                 );
+                cart.addItem(newItem);
                 return cartItemRepository.save(newItem);
             });
 

--- a/src/main/java/com/example/i_commerce/domain/cart/service/CartService.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/service/CartService.java
@@ -1,0 +1,59 @@
+package com.example.i_commerce.domain.cart.service;
+
+
+import com.example.i_commerce.domain.cart.controller.request.AddCartItemRequest;
+import com.example.i_commerce.domain.cart.controller.response.AddCartItemResponse;
+import com.example.i_commerce.domain.cart.entity.Cart;
+import com.example.i_commerce.domain.cart.entity.CartItem;
+import com.example.i_commerce.domain.cart.exception.CartErrorCode;
+import com.example.i_commerce.domain.cart.infrastructure.ProductClient;
+import com.example.i_commerce.domain.cart.infrastructure.ProductItemInfo;
+import com.example.i_commerce.domain.cart.repository.CartItemRepository;
+import com.example.i_commerce.domain.cart.repository.CartRepository;
+import com.example.i_commerce.global.exception.AppException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CartService {
+
+    private final CartRepository cartRepository;
+    private final CartItemRepository cartItemRepository;
+    private final ProductClient productClient;
+
+    public AddCartItemResponse addCartItem(Long userId, AddCartItemRequest request) {
+
+        ProductItemInfo productItemInfo =
+            productClient.getProductItem(request.productItemId());
+        if(!productItemInfo.isAvailable()) {
+            throw new AppException(CartErrorCode.PRODUCT_NOT_AVAILABLE);
+        }
+
+        Cart cart = cartRepository.findByUserIdWithItems(userId)
+            .orElseGet(() -> cartRepository.save(Cart.create(userId)));
+
+        CartItem cartItem = cart.findCartItem(request.productItemId())
+            .map(existingItem -> {
+                existingItem.increaseQuantity(
+                    request.quantity(), productItemInfo.stockQuantity()
+                );
+                return existingItem;
+            }).orElseGet(() -> {
+                CartItem newItem = CartItem.of(
+                    cart,
+                    productItemInfo.productItemId(),
+                    productItemInfo.productName(),
+                    productItemInfo.price(),
+                    productItemInfo.displayOptionName(),
+                    request.quantity()
+                );
+                return cartItemRepository.save(newItem);
+            });
+
+        return AddCartItemResponse.from(cartItem);
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/ProductQueryService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/ProductQueryService.java
@@ -10,9 +10,14 @@ import com.example.i_commerce.domain.product.entity.Product;
 import com.example.i_commerce.domain.product.entity.ProductAttribute;
 import com.example.i_commerce.domain.product.entity.ProductImage;
 import com.example.i_commerce.domain.product.entity.ProductItem;
+import com.example.i_commerce.domain.product.entity.ProductItemStatus;
 import com.example.i_commerce.domain.product.exception.ProductErrorCode;
+import com.example.i_commerce.domain.product.facade.ProductQueryFacade;
+import com.example.i_commerce.domain.product.facade.dto.ProductItemInfoResponse;
 import com.example.i_commerce.domain.product.repository.ProductAttributeRepository;
 import com.example.i_commerce.domain.product.repository.ProductImageRepository;
+import com.example.i_commerce.domain.product.repository.ProductItemInfoProjection;
+import com.example.i_commerce.domain.product.repository.ProductItemRepository;
 import com.example.i_commerce.domain.product.repository.ProductQueryRepository;
 import com.example.i_commerce.global.exception.AppException;
 import java.util.List;
@@ -23,14 +28,31 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class ProductQueryService {
+public class ProductQueryService implements ProductQueryFacade {
 
     private final OptionGroupBuilder optionGroupBuilder;
     private final OptionLookupBuilder optionLookupBuilder;
 
     private final ProductQueryRepository productQueryRepository;
     private final ProductImageRepository productImageRepository;
+    private final ProductItemRepository productItemRepository;
     private final ProductAttributeRepository productAttributeRepository;
+
+    @Override
+    public ProductItemInfoResponse getProductItemInfo(Long itemId) {
+
+        ProductItemInfoProjection itemInfoProjection = productItemRepository.findItemInfoById(itemId)
+            .orElseThrow(() -> new AppException(ProductErrorCode.PRODUCT_ITEM_NOT_FOUND));
+
+        return ProductItemInfoResponse.builder()
+            .productItemId(itemInfoProjection.getProductItemId())
+            .productName(itemInfoProjection.getProductName())
+            .price(itemInfoProjection.getPrice())
+            .displayOptionName(itemInfoProjection.getDisplayOptionName())
+            .stockQuantity(itemInfoProjection.getStockQuantity())
+            .onSale(itemInfoProjection.getStatus() == ProductItemStatus.ON_SALE)
+            .build();
+    }
 
 
     public ProductDetailResponse getProductDetail(Long productId, Long itemId) {

--- a/src/main/java/com/example/i_commerce/domain/product/facade/ProductQueryFacade.java
+++ b/src/main/java/com/example/i_commerce/domain/product/facade/ProductQueryFacade.java
@@ -1,0 +1,7 @@
+package com.example.i_commerce.domain.product.facade;
+
+import com.example.i_commerce.domain.product.facade.dto.ProductItemInfoResponse;
+
+public interface ProductQueryFacade {
+    ProductItemInfoResponse getProductItemInfo(Long productItem);
+}

--- a/src/main/java/com/example/i_commerce/domain/product/facade/dto/ProductItemInfoResponse.java
+++ b/src/main/java/com/example/i_commerce/domain/product/facade/dto/ProductItemInfoResponse.java
@@ -1,0 +1,15 @@
+package com.example.i_commerce.domain.product.facade.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ProductItemInfoResponse(
+    Long productItemId,
+    String productName,
+    Integer price,
+    String displayOptionName,
+    Integer stockQuantity,
+    boolean onSale
+) {
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/repository/ProductItemInfoProjection.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/ProductItemInfoProjection.java
@@ -1,0 +1,12 @@
+package com.example.i_commerce.domain.product.repository;
+
+import com.example.i_commerce.domain.product.entity.ProductItemStatus;
+
+public interface ProductItemInfoProjection {
+    Long getProductItemId();
+    String getProductName();
+    Integer getPrice();
+    String getDisplayOptionName();
+    Integer getStockQuantity();
+    ProductItemStatus getStatus();
+}

--- a/src/main/java/com/example/i_commerce/domain/product/repository/ProductItemRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/ProductItemRepository.java
@@ -1,7 +1,27 @@
 package com.example.i_commerce.domain.product.repository;
 
 import com.example.i_commerce.domain.product.entity.ProductItem;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ProductItemRepository extends JpaRepository<ProductItem, Long> {
+
+    @Query("""
+        SELECT
+            pi.id as productItemId,
+            p.name as productName,
+            pi.price as price,
+            pi.displayOptionName as displayOptionName,
+            s.quantity as stockQuantity,
+            pi.status as status
+        FROM ProductItem pi
+        JOIN pi.product p
+        JOIN pi.stock s
+        WHERE pi.id = :itemId
+        """)
+    Optional<ProductItemInfoProjection> findItemInfoById(@Param("itemId") Long itemId);
 }


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
- closed #54 -> develop


## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
장바구니에 상품을 추가하는 기능을 개발했습니다. 
- 로그인한 유저의 Id로 장바구니를 찾고, 없으면 새로 추가합니다.
- 추가하려는 아이템이 이미 존재한다면 수량을 올리고, 없으면 새로 추가합니다.
- 상품 아이템의 재고를 초과해서 주문시 오류를 반환합니다.


추가로 다음 작업도 포함되었습니다.
- 상품 도메인에 상품 아이템 기본 정보 반환하기위한 객체와 인터페이스 추가, 서비스 코드 추가
- 해당 인터페이스 호출하는 클래스 장바구니 도메인에 추가 


## ⭐️ Run Test
[//]: # (없다면 N/A)
postman으로 동작을 확인했습니다.
<details>
  <summary>장바구니 상품 추가 확인</summary>

<img width="955" height="495" alt="image" src="https://github.com/user-attachments/assets/52281358-b944-41be-a147-9e63e43b1ac0" />

</details>
그 외 오류 응답도 확인했습니다.



## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
- 다른 도메인이랑 통신하는 구조를 전체적으로 고치고 싶다고는 생각하고 있는데 일단 해당 브런치에서 고칠 작업도 아닌 것 같고 고민을 많이 하고 팀컨벤션으로 정하면 좋을 것 같아서.. 구조는 추후 좀 더 고민해서 전체적으로 리팩터링하면 좋을 것 같습니다. 🥲
- 궁금하신 점, 개선 필요한 부분 등 편하게 의견 주세요! 

