### PR TITLE
Feat: 카테고리 제공 옵션 조회 API

### DIFF
--- a/src/main/java/com/example/i_commerce/domain/product/application/mapper/CategoryOptionMapper.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/mapper/CategoryOptionMapper.java
@@ -1,0 +1,54 @@
+package com.example.i_commerce.domain.product.application.mapper;
+
+
+import com.example.i_commerce.domain.product.controller.response.CategoryOptionGroupResponse;
+import com.example.i_commerce.domain.product.controller.response.CategoryOptionGroupResponse.CategoryOptionValueResponse;
+import com.example.i_commerce.domain.product.repository.projection.CategoryOptionProjection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CategoryOptionMapper {
+
+
+    public List<CategoryOptionGroupResponse> toGroupedResponseList(
+        List<CategoryOptionProjection> projections
+    ) {
+        if (projections.isEmpty()) {
+            return List.of();
+        }
+
+        return projections.stream()
+            .collect(Collectors.groupingBy(
+                CategoryOptionProjection::getOptionType,
+                LinkedHashMap::new,
+                Collectors.toList()
+            ))
+            .entrySet().stream()
+            .map(this::toGroupResponse)
+            .toList();
+    }
+
+    private CategoryOptionGroupResponse toGroupResponse(
+        Entry<String, List<CategoryOptionProjection>> entry
+    ) {
+        return CategoryOptionGroupResponse.builder()
+            .optionType(entry.getKey())
+            .optionValues(entry.getValue().stream()
+                .map(p -> CategoryOptionValueResponse.builder()
+                    .categoryOptionId(p.getCategoryOptionId())
+                    .optionId(p.getOptionId())
+                    .value(p.getOptionValue())
+                    .displayName(p.getDisplayName())
+                    .inputType(p.getInputType())
+                    .required(p.getRequired())
+                    .build()
+                ).toList()
+            ).build();
+    }
+
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryOptionService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryOptionService.java
@@ -1,0 +1,37 @@
+package com.example.i_commerce.domain.product.application.service;
+
+
+import com.example.i_commerce.domain.product.application.mapper.CategoryOptionMapper;
+import com.example.i_commerce.domain.product.controller.response.CategoryOptionGroupResponse;
+import com.example.i_commerce.domain.product.entity.Category;
+import com.example.i_commerce.domain.product.exception.ProductErrorCode;
+import com.example.i_commerce.domain.product.repository.CategoryOptionRepository;
+import com.example.i_commerce.domain.product.repository.CategoryRepository;
+import com.example.i_commerce.domain.product.repository.projection.CategoryOptionProjection;
+import com.example.i_commerce.global.exception.AppException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryOptionService {
+
+    private final CategoryRepository categoryRepository;
+    private final CategoryOptionRepository categoryOptionRepository;
+
+    private final CategoryOptionMapper categoryOptionMapper;
+
+    @Transactional(readOnly = true)
+    public List<CategoryOptionGroupResponse> getOptionsByCategory(Long categoryId) {
+        Category category = categoryRepository.findById(categoryId)
+            .orElseThrow(() -> new AppException(ProductErrorCode.CATEGORY_NOT_FOUND));
+
+        List<CategoryOptionProjection> projections = categoryOptionRepository
+            .findOptionsByCategoryId(category.getId());
+
+        return categoryOptionMapper.toGroupedResponseList(projections);
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryOptionService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryOptionService.java
@@ -25,11 +25,13 @@ public class CategoryOptionService {
 
     @Transactional(readOnly = true)
     public List<CategoryOptionGroupResponse> getOptionsByCategory(Long categoryId) {
-        Category category = categoryRepository.findById(categoryId)
-            .orElseThrow(() -> new AppException(ProductErrorCode.CATEGORY_NOT_FOUND));
+
+        if(!categoryRepository.existsById(categoryId)) {
+            throw new AppException(ProductErrorCode.CATEGORY_NOT_FOUND);
+        }
 
         List<CategoryOptionProjection> projections = categoryOptionRepository
-            .findOptionsByCategoryId(category.getId());
+            .findOptionsByCategoryId(categoryId);
 
         return categoryOptionMapper.toGroupedResponseList(projections);
     }

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/ProductQueryService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/ProductQueryService.java
@@ -16,7 +16,7 @@ import com.example.i_commerce.domain.product.facade.ProductQueryFacade;
 import com.example.i_commerce.domain.product.facade.dto.ProductItemInfoResponse;
 import com.example.i_commerce.domain.product.repository.ProductAttributeRepository;
 import com.example.i_commerce.domain.product.repository.ProductImageRepository;
-import com.example.i_commerce.domain.product.repository.ProductItemInfoProjection;
+import com.example.i_commerce.domain.product.repository.projection.ProductItemInfoProjection;
 import com.example.i_commerce.domain.product.repository.ProductItemRepository;
 import com.example.i_commerce.domain.product.repository.ProductQueryRepository;
 import com.example.i_commerce.global.exception.AppException;

--- a/src/main/java/com/example/i_commerce/domain/product/controller/CategoryOptionController.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/CategoryOptionController.java
@@ -1,0 +1,27 @@
+package com.example.i_commerce.domain.product.controller;
+
+import com.example.i_commerce.domain.product.application.service.CategoryOptionService;
+import com.example.i_commerce.domain.product.controller.response.CategoryOptionGroupResponse;
+import com.example.i_commerce.global.common.response.ApiResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/categories/{categoryId}/options")
+public class CategoryOptionController {
+
+    private final CategoryOptionService categoryOptionService;
+
+    @GetMapping
+    public ApiResponse<List<CategoryOptionGroupResponse>> getCategoryOptions(
+        @PathVariable Long categoryId
+    ) {
+        return ApiResponse.success(categoryOptionService.getOptionsByCategory(categoryId));
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/controller/response/CategoryOptionGroupResponse.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/response/CategoryOptionGroupResponse.java
@@ -1,0 +1,24 @@
+package com.example.i_commerce.domain.product.controller.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record CategoryOptionGroupResponse(
+    String optionType,
+    List<CategoryOptionValueResponse> optionValues
+) {
+
+    @Builder
+    public record CategoryOptionValueResponse(
+        Long categoryOptionId,
+        Long optionId,
+        String value,
+        String displayName,
+        String inputType,
+        Boolean required
+    ){
+
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/entity/Option.java
+++ b/src/main/java/com/example/i_commerce/domain/product/entity/Option.java
@@ -29,13 +29,13 @@ public class Option extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 100)
+    @Column(length = 100, nullable = false)
     private String type;
 
-    @Column(length = 100)
+    @Column(length = 100, nullable = false)
     private String value;
 
-    @Column(length = 100)
+    @Column(length = 100, nullable = false)
     private String displayName;
 
     @Column(length = 100)

--- a/src/main/java/com/example/i_commerce/domain/product/repository/CategoryOptionRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/CategoryOptionRepository.java
@@ -1,8 +1,12 @@
 package com.example.i_commerce.domain.product.repository;
 
 import com.example.i_commerce.domain.product.entity.CategoryOption;
+import com.example.i_commerce.domain.product.repository.projection.CategoryOptionProjection;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 
@@ -11,4 +15,21 @@ public interface CategoryOptionRepository extends JpaRepository<CategoryOption, 
 
     Optional<CategoryOption> findByCategoryId(Long categoryId);
 
+    @Query("""
+    SELECT
+        co.id AS categoryOptionId,
+        co.required AS required,
+        o.id AS optionId,
+        o.type AS optionType,
+        o.value AS optionValue,
+        o.displayName AS displayName,
+        o.inputType AS inputType
+    FROM CategoryOption co
+    JOIN co.option o
+    WHERE co.category.id = :categoryId
+    ORDER BY o.type, o.value
+    """)
+    List<CategoryOptionProjection> findOptionsByCategoryId(
+        @Param("categoryId") Long categoryId
+    );
 }

--- a/src/main/java/com/example/i_commerce/domain/product/repository/ProductItemRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/ProductItemRepository.java
@@ -1,6 +1,7 @@
 package com.example.i_commerce.domain.product.repository;
 
 import com.example.i_commerce.domain.product.entity.ProductItem;
+import com.example.i_commerce.domain.product.repository.projection.ProductItemInfoProjection;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/example/i_commerce/domain/product/repository/projection/CategoryOptionProjection.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/projection/CategoryOptionProjection.java
@@ -1,0 +1,12 @@
+package com.example.i_commerce.domain.product.repository.projection;
+
+public interface CategoryOptionProjection {
+    Long getCategoryOptionId();
+    Boolean getRequired();
+    Long getOptionId();
+    String getOptionType();
+    String getOptionValue();
+    String getDisplayName();
+    String getInputType();
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/repository/projection/ProductItemInfoProjection.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/projection/ProductItemInfoProjection.java
@@ -1,4 +1,4 @@
-package com.example.i_commerce.domain.product.repository;
+package com.example.i_commerce.domain.product.repository.projection;
 
 import com.example.i_commerce.domain.product.entity.ProductItemStatus;
 


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
- closed #61 -> develop


## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
카테고리가 제공하는 옵션 조회 API를 개발했습니다. 
- 카테고리 id는 경로에서 받아오며 일치하는 카테고리가 없는 경우 오류가 반환됩니다.
- 카테고리가 제공하는 옵션이 없는 경우 빈 List가 반환됩니다.

## ⭐️ Run Test
postman을 통해 정상 응답, 오류 응답 확인했습니다.

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
- 기타 궁금하신 점, 개선 필요한 부분 편하게 말씀해주세요! 