### PR TITLE
Feat: 주문 및 결제 취소 시 실시간 재고 연동

### DIFF
--- a/src/main/java/com/example/i_commerce/domain/order/event/dto/DeliveryCancelRequestEvent.java
+++ b/src/main/java/com/example/i_commerce/domain/order/event/dto/DeliveryCancelRequestEvent.java
@@ -1,4 +1,4 @@
-package com.example.i_commerce.domain.order.service.dto;
+package com.example.i_commerce.domain.order.event.dto;
 
 public record DeliveryCancelRequestEvent(
         Long orderId

--- a/src/main/java/com/example/i_commerce/domain/order/event/dto/PaymentApprovedEvent.java
+++ b/src/main/java/com/example/i_commerce/domain/order/event/dto/PaymentApprovedEvent.java
@@ -1,0 +1,6 @@
+package com.example.i_commerce.domain.order.event.dto;
+
+public record PaymentApprovedEvent(
+        Long orderId
+) {
+}

--- a/src/main/java/com/example/i_commerce/domain/order/event/dto/PaymentStatusChangedEvent.java
+++ b/src/main/java/com/example/i_commerce/domain/order/event/dto/PaymentStatusChangedEvent.java
@@ -3,7 +3,7 @@ package com.example.i_commerce.domain.order.event.dto;
 import com.example.i_commerce.domain.order.entity.Payment;
 import com.example.i_commerce.domain.order.entity.emuns.PaymentStatus;
 
-public record PaymentCompletedEvent(
+public record PaymentStatusChangedEvent(
         Payment payment,
         PaymentStatus previousStatus,
         String reason,
@@ -11,4 +11,6 @@ public record PaymentCompletedEvent(
         String pgTid,
         String rawData
 ) {
+
+
 }

--- a/src/main/java/com/example/i_commerce/domain/order/event/listener/DeliveryListener.java
+++ b/src/main/java/com/example/i_commerce/domain/order/event/listener/DeliveryListener.java
@@ -1,12 +1,8 @@
 package com.example.i_commerce.domain.order.event.listener;
 
-import com.example.i_commerce.domain.order.entity.Delivery;
-import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
-import com.example.i_commerce.domain.order.event.dto.PaymentCompletedEvent;
+import com.example.i_commerce.domain.order.event.dto.PaymentApprovedEvent;
 import com.example.i_commerce.domain.order.service.DeliveryService;
-import com.example.i_commerce.domain.order.service.dto.DeliveryCancelRequestEvent;
-import com.example.i_commerce.global.exception.AppException;
-import java.util.List;
+import com.example.i_commerce.domain.order.event.dto.DeliveryCancelRequestEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -22,7 +18,7 @@ public class DeliveryListener {
     private final DeliveryService deliveryService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handlePaymentCompleted(PaymentCompletedEvent event) {
+    public void handlePaymentCompleted(PaymentApprovedEvent event) {
         deliveryService.createDelivery(event);
     }
 

--- a/src/main/java/com/example/i_commerce/domain/order/event/listener/PaymentLogListener.java
+++ b/src/main/java/com/example/i_commerce/domain/order/event/listener/PaymentLogListener.java
@@ -1,6 +1,6 @@
 package com.example.i_commerce.domain.order.event.listener;
 
-import com.example.i_commerce.domain.order.event.dto.PaymentCompletedEvent;
+import com.example.i_commerce.domain.order.event.dto.PaymentStatusChangedEvent;
 import com.example.i_commerce.domain.order.service.PaymentHistoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,7 +16,7 @@ public class PaymentLogListener {
     private final PaymentHistoryService paymentHistoryService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void createPaymentHistoryRequest(PaymentCompletedEvent event) {
+    public void createPaymentHistoryRequest(PaymentStatusChangedEvent event) {
         paymentHistoryService.createPaymentHistory(event);
     }
 }

--- a/src/main/java/com/example/i_commerce/domain/order/service/DeliveryService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/DeliveryService.java
@@ -4,12 +4,12 @@ import com.example.i_commerce.domain.order.entity.Delivery;
 import com.example.i_commerce.domain.order.entity.Order;
 import com.example.i_commerce.domain.order.entity.OrderProduct;
 import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
-import com.example.i_commerce.domain.order.event.dto.PaymentCompletedEvent;
+import com.example.i_commerce.domain.order.event.dto.PaymentApprovedEvent;
 import com.example.i_commerce.domain.order.exception.OrderErrorCode;
 import com.example.i_commerce.domain.order.exception.PaymentErrorCode;
 import com.example.i_commerce.domain.order.repository.DeliveryRepository;
 import com.example.i_commerce.domain.order.repository.OrderRepository;
-import com.example.i_commerce.domain.order.service.dto.DeliveryCancelRequestEvent;
+import com.example.i_commerce.domain.order.event.dto.DeliveryCancelRequestEvent;
 import com.example.i_commerce.domain.product.entity.ProductItem;
 import com.example.i_commerce.domain.product.repository.ProductItemRepository;
 import com.example.i_commerce.global.exception.AppException;
@@ -18,10 +18,12 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class DeliveryService {
@@ -31,9 +33,9 @@ public class DeliveryService {
     private final ProductItemRepository productItemRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void createDelivery(PaymentCompletedEvent event) {
+    public void createDelivery(PaymentApprovedEvent event) {
 
-        Order order = orderRepository.findById(event.payment().getOrder().getId()).orElseThrow(() -> new AppException(OrderErrorCode.ORDER_NOT_FOUND));
+        Order order = orderRepository.findById(event.orderId()).orElseThrow(() -> new AppException(OrderErrorCode.ORDER_NOT_FOUND));
 
         List<Long> productIds = order.getOrderProducts().stream()
                 .map(OrderProduct::getProductSkuId).toList();
@@ -61,8 +63,10 @@ public class DeliveryService {
 
     }
 
+    @Transactional
     public void cancelDelivery(DeliveryCancelRequestEvent event) {
-        List<Delivery> deliveries = deliveryRepository.findAllByOrderId(event.orderId());
+        Order order = orderRepository.findById(event.orderId()).orElseThrow(() -> new AppException(OrderErrorCode.ORDER_NOT_FOUND));
+        List<Delivery> deliveries = order.getDeliveries();
 
         for (Delivery delivery : deliveries) {
             if (delivery.getDeliveryStatus() == DeliveryStatus.SHIPPING ||

--- a/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
@@ -23,6 +23,8 @@ import com.example.i_commerce.domain.order.service.dto.OrderDetailResponse.Payme
 import com.example.i_commerce.domain.order.service.dto.OrderSummaryResponse;
 import com.example.i_commerce.domain.product.entity.ProductItem;
 import com.example.i_commerce.domain.product.exception.ProductErrorCode;
+import com.example.i_commerce.domain.product.facade.StockFacade;
+import com.example.i_commerce.domain.product.facade.dto.StockDeductCommand;
 import com.example.i_commerce.domain.product.repository.ProductItemRepository;
 import com.example.i_commerce.global.common.response.ApiResponse;
 import com.example.i_commerce.global.exception.AppException;
@@ -47,6 +49,7 @@ public class OrderService {
     private final PaymentRepository paymentRepository;
     private final DeliveryAddressService deliveryAddressService;
     private final OrderProductRepository orderProductRepository;
+    private final StockFacade stockFacade;
 
     @Transactional
     public ApiResponse<CreateOrderResponse> createOrder(Long memberId, CreateOrderRequest dto) {
@@ -98,6 +101,16 @@ public class OrderService {
         orderProducts.forEach(orderProduct -> orderProduct.assignOrder(order));
 
         orderRepository.save(order);
+
+        List<StockDeductCommand> stockDeductCommands = dto.items().stream()
+                .map(orderItemDto ->
+                        new StockDeductCommand(
+                                orderItemDto.productId(),
+                                orderItemDto.quantity(),
+                                order.getId()))
+                .toList();
+
+        stockFacade.deductStock(stockDeductCommands);
 
         Payment payment = paymentRepository.save(Payment.builder()
                 .order(order)

--- a/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
@@ -119,7 +119,6 @@ public class OrderService {
                 .payStatus(PaymentStatus.READY)
                 .build());
 
-       //TODO : 재고 차감
         String firstProductName = order.getOrderProducts().getFirst().getProductName();
 
         return ApiResponse.success(CreateOrderResponse.of(order, payment, firstProductName));

--- a/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
@@ -118,8 +118,8 @@ public class OrderService {
                 .cancelableAmount(0)
                 .payStatus(PaymentStatus.READY)
                 .build());
-
-        String firstProductName = order.getOrderProducts().getFirst().getProductName();
+        
+        String firstProductName = order.getOrderProducts().stream().findFirst().map(OrderProduct::getProductName).orElse("");
 
         return ApiResponse.success(CreateOrderResponse.of(order, payment, firstProductName));
 

--- a/src/main/java/com/example/i_commerce/domain/order/service/PaymentHistoryService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/PaymentHistoryService.java
@@ -3,9 +3,8 @@ package com.example.i_commerce.domain.order.service;
 import com.example.i_commerce.domain.order.entity.Order;
 import com.example.i_commerce.domain.order.entity.Payment;
 import com.example.i_commerce.domain.order.entity.PaymentHistory;
-import com.example.i_commerce.domain.order.event.dto.PaymentCompletedEvent;
+import com.example.i_commerce.domain.order.event.dto.PaymentStatusChangedEvent;
 import com.example.i_commerce.domain.order.repository.PaymentHistoryRepository;
-import com.example.i_commerce.domain.order.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -18,7 +17,7 @@ public class PaymentHistoryService {
     private final PaymentHistoryRepository paymentHistoryRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void createPaymentHistory(PaymentCompletedEvent event) {
+    public void createPaymentHistory(PaymentStatusChangedEvent event) {
         Payment payment = event.payment();
         Order order = payment.getOrder();
         paymentHistoryRepository.save(

--- a/src/main/java/com/example/i_commerce/domain/order/service/PaymentService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/PaymentService.java
@@ -1,21 +1,25 @@
 package com.example.i_commerce.domain.order.service;
 
+import com.example.i_commerce.domain.order.entity.Delivery;
 import com.example.i_commerce.domain.order.entity.Order;
 import com.example.i_commerce.domain.order.entity.Payment;
 import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
 import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
 import com.example.i_commerce.domain.order.entity.emuns.PaymentStatus;
-import com.example.i_commerce.domain.order.event.dto.PaymentCompletedEvent;
+import com.example.i_commerce.domain.order.event.dto.DeliveryCancelRequestEvent;
+import com.example.i_commerce.domain.order.event.dto.PaymentApprovedEvent;
+import com.example.i_commerce.domain.order.event.dto.PaymentStatusChangedEvent;
 import com.example.i_commerce.domain.order.exception.PaymentErrorCode;
 import com.example.i_commerce.domain.order.repository.PaymentRepository;
-import com.example.i_commerce.domain.order.service.dto.DeliveryCancelRequestEvent;
 import com.example.i_commerce.domain.order.service.dto.PaymentCancelRequest;
 import com.example.i_commerce.domain.order.service.dto.PaymentConfirmRequest;
 import com.example.i_commerce.domain.order.service.dto.PaymentDetailResponse;
+import com.example.i_commerce.domain.product.facade.StockFacade;
 import com.example.i_commerce.global.exception.AppException;
 import jakarta.annotation.PostConstruct;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +43,7 @@ public class PaymentService {
     private final PaymentRepository paymentRepository;
     private final ApplicationEventPublisher publisher;
     private final RestTemplate restTemplate;
+    private final StockFacade stockFacade;
 
     @Value("${toss.secretKey}")
     private String SECRET_KEY;
@@ -72,7 +77,7 @@ public class PaymentService {
     @Transactional
     public void confirmPayment(PaymentConfirmRequest dto) {
         if (dto.tossOrderId() == null || !dto.tossOrderId().contains("_")) {
-            throw new AppException(PaymentErrorCode.INVALID_PAYMENT_REQUEST); // 400 Bad Request
+            throw new AppException(PaymentErrorCode.INVALID_PAYMENT_REQUEST);
         }
         Long paymentId = Long.valueOf(dto.tossOrderId().split("_")[1]);
         Payment payment = paymentRepository.findById(paymentId)
@@ -112,7 +117,9 @@ public class PaymentService {
                 payment.completePayment(pgTid);
                 payment.getOrder().changeOrderStatus(OrderStatus.CONFIRMED);
 
-                publisher.publishEvent(new PaymentCompletedEvent(
+                publisher.publishEvent(new PaymentApprovedEvent(payment.getOrder().getId()));
+
+                publisher.publishEvent(new PaymentStatusChangedEvent(
                         payment,
                         previousStatus,
                         "결제 완료",
@@ -134,8 +141,6 @@ public class PaymentService {
         Payment payment = paymentRepository.findById(dto.paymentId())
                 .orElseThrow(() -> new AppException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
-
-
         if(!Objects.equals(dto.paymentKey(), payment.getPgTid())) {
             throw new AppException(PaymentErrorCode.INVALID_PAYMENT_KEY);
         }
@@ -149,6 +154,27 @@ public class PaymentService {
         }
 
         publisher.publishEvent(new DeliveryCancelRequestEvent(payment.getOrder().getId()));
+        Order order = payment.getOrder();
+//        List<Delivery> deliveries = order.getDeliveries();
+//        log.info("--- 반복문 시작 전 ---");
+//        for (Delivery d : deliveries) {
+//            // d.hashCode()는 equals/hashCode가 없으므로 객체의 메모리 주소 기반 값을 리턴합니다.
+//            log.info("Delivery ID: {}, 객체 주소값: {}, 상태: {}", d.getId(), System.identityHashCode(d), d.getDeliveryStatus());
+//        }
+//
+//        for (Delivery delivery : deliveries) {
+//            if (delivery.getDeliveryStatus() == DeliveryStatus.SHIPPING ||
+//                    delivery.getDeliveryStatus() == DeliveryStatus.ARRIVED) {
+//                throw new AppException(PaymentErrorCode.PAYMENT_CANCEL_IMPOSSIBLE_ALREADY_SHIPPED);
+//            }
+//
+//            delivery.changeDeliveryStatus(DeliveryStatus.CANCELLED);
+//        }
+//
+//        log.info("--- 반복문 종료 후 ---");
+//        for (Delivery d : payment.getOrder().getDeliveries()) {
+//            log.info("Delivery ID: {}, 객체 주소값: {}, 상태: {}", d.getId(), System.identityHashCode(d), d.getDeliveryStatus());
+//        }
 
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Basic " + encodedKey);
@@ -173,10 +199,11 @@ public class PaymentService {
                 String pgTid = (String) response.getBody().get("paymentKey");
 
                 payment.cancelPayment(dto.cancelAmount());
-                payment.getOrder().changeOrderStatus(OrderStatus.CANCELLED);
-                //TODO: 재고 rollback
+                order.changeOrderStatus(OrderStatus.CANCELLED);
 
-                publisher.publishEvent(new PaymentCompletedEvent(
+                stockFacade.rollbackStocks(order.getId());
+
+                publisher.publishEvent(new PaymentStatusChangedEvent(
                         payment,
                         previousStatus,
                         dto.cancelReason(),

--- a/src/main/java/com/example/i_commerce/domain/order/service/PaymentService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/PaymentService.java
@@ -154,32 +154,12 @@ public class PaymentService {
         }
 
         publisher.publishEvent(new DeliveryCancelRequestEvent(payment.getOrder().getId()));
+
         Order order = payment.getOrder();
-//        List<Delivery> deliveries = order.getDeliveries();
-//        log.info("--- 반복문 시작 전 ---");
-//        for (Delivery d : deliveries) {
-//            // d.hashCode()는 equals/hashCode가 없으므로 객체의 메모리 주소 기반 값을 리턴합니다.
-//            log.info("Delivery ID: {}, 객체 주소값: {}, 상태: {}", d.getId(), System.identityHashCode(d), d.getDeliveryStatus());
-//        }
-//
-//        for (Delivery delivery : deliveries) {
-//            if (delivery.getDeliveryStatus() == DeliveryStatus.SHIPPING ||
-//                    delivery.getDeliveryStatus() == DeliveryStatus.ARRIVED) {
-//                throw new AppException(PaymentErrorCode.PAYMENT_CANCEL_IMPOSSIBLE_ALREADY_SHIPPED);
-//            }
-//
-//            delivery.changeDeliveryStatus(DeliveryStatus.CANCELLED);
-//        }
-//
-//        log.info("--- 반복문 종료 후 ---");
-//        for (Delivery d : payment.getOrder().getDeliveries()) {
-//            log.info("Delivery ID: {}, 객체 주소값: {}, 상태: {}", d.getId(), System.identityHashCode(d), d.getDeliveryStatus());
-//        }
 
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Basic " + encodedKey);
         headers.setContentType(MediaType.APPLICATION_JSON);
-
 
         Map<String, Object> params = new HashMap<>();
         params.put("cancelReason", dto.cancelReason());

--- a/src/test/java/com/example/i_commerce/domain/order/service/DeliveryServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/service/DeliveryServiceTest.java
@@ -15,11 +15,11 @@ import com.example.i_commerce.domain.order.entity.Order;
 import com.example.i_commerce.domain.order.entity.OrderProduct;
 import com.example.i_commerce.domain.order.entity.Payment;
 import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
-import com.example.i_commerce.domain.order.event.dto.PaymentCompletedEvent;
+import com.example.i_commerce.domain.order.event.dto.PaymentApprovedEvent;
 import com.example.i_commerce.domain.order.exception.PaymentErrorCode;
 import com.example.i_commerce.domain.order.repository.DeliveryRepository;
 import com.example.i_commerce.domain.order.repository.OrderRepository;
-import com.example.i_commerce.domain.order.service.dto.DeliveryCancelRequestEvent;
+import com.example.i_commerce.domain.order.event.dto.DeliveryCancelRequestEvent;
 import com.example.i_commerce.domain.product.entity.Product;
 import com.example.i_commerce.domain.product.entity.ProductItem;
 import com.example.i_commerce.domain.product.repository.ProductItemRepository;
@@ -72,7 +72,7 @@ class DeliveryServiceTest {
         given(order.getOrderProducts()).willReturn(List.of(item1, item2));
 
         // Event 모킹
-        PaymentCompletedEvent event = mock(PaymentCompletedEvent.class);
+        PaymentApprovedEvent event = mock(PaymentApprovedEvent.class);
         Payment payment = mock(Payment.class);
         given(event.payment()).willReturn(payment);
         given(payment.getOrder()).willReturn(order);
@@ -114,7 +114,7 @@ class DeliveryServiceTest {
     @DisplayName("주문 정보가 없으면 AppException이 발생한다")
     void createDelivery_OrderNotFound() {
         // given
-        PaymentCompletedEvent event = mock(PaymentCompletedEvent.class);
+        PaymentApprovedEvent event = mock(PaymentApprovedEvent.class);
         Payment payment = mock(Payment.class);
         Order order = mock(Order.class);
 

--- a/src/test/java/com/example/i_commerce/domain/order/service/DeliveryServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/service/DeliveryServiceTest.java
@@ -66,7 +66,6 @@ class DeliveryServiceTest {
         OrderProduct item1 = mock(OrderProduct.class);
         OrderProduct item2 = mock(OrderProduct.class);
 
-        given(order.getId()).willReturn(orderId);
         given(item1.getProductSkuId()).willReturn(skuId1);
         given(item2.getProductSkuId()).willReturn(skuId2);
         given(order.getOrderProducts()).willReturn(List.of(item1, item2));
@@ -74,8 +73,7 @@ class DeliveryServiceTest {
         // Event 모킹
         PaymentApprovedEvent event = mock(PaymentApprovedEvent.class);
         Payment payment = mock(Payment.class);
-        given(event.payment()).willReturn(payment);
-        given(payment.getOrder()).willReturn(order);
+        given(event.orderId()).willReturn(orderId);
 
         // Repository 동작 정의
         given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
@@ -118,9 +116,7 @@ class DeliveryServiceTest {
         Payment payment = mock(Payment.class);
         Order order = mock(Order.class);
 
-        given(event.payment()).willReturn(payment);
-        given(payment.getOrder()).willReturn(order);
-        given(order.getId()).willReturn(1L);
+        given(event.orderId()).willReturn(1L);
         given(orderRepository.findById(1L)).willReturn(Optional.empty());
 
         // when & then
@@ -135,12 +131,14 @@ class DeliveryServiceTest {
         Long orderId = 1L;
         DeliveryCancelRequestEvent event = new DeliveryCancelRequestEvent(orderId);
 
+        Order order = mock(Order.class);
         // 가상의 배송 전(READY) 객체 생성 (실제 엔티티 구현체에 맞게 빌더나 생성자 사용)
         Delivery delivery1 = createDelivery(orderId, DeliveryStatus.PREPARING);
         Delivery delivery2 = createDelivery(orderId, DeliveryStatus.PREPARING);
         List<Delivery> mockDeliveries = List.of(delivery1, delivery2);
 
-        given(deliveryRepository.findAllByOrderId(orderId)).willReturn(mockDeliveries);
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(order.getDeliveries()).willReturn(mockDeliveries);
 
         // when
         deliveryService.cancelDelivery(event);
@@ -157,12 +155,15 @@ class DeliveryServiceTest {
         Long orderId = 1L;
         DeliveryCancelRequestEvent event = new DeliveryCancelRequestEvent(orderId);
 
+        Order order = mock(Order.class);
+
         Delivery delivery1 = createDelivery(orderId, DeliveryStatus.PREPARING);
         Delivery delivery2 = createDelivery(orderId, DeliveryStatus.SHIPPING);
 
         List<Delivery> mockDeliveries = List.of(delivery1, delivery2);
 
-        given(deliveryRepository.findAllByOrderId(orderId)).willReturn(mockDeliveries);
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(order.getDeliveries()).willReturn(mockDeliveries);
 
         // when & then
         assertThatThrownBy(() -> deliveryService.cancelDelivery(event))
@@ -177,10 +178,13 @@ class DeliveryServiceTest {
         Long orderId = 1L;
         DeliveryCancelRequestEvent event = new DeliveryCancelRequestEvent(orderId);
 
+        Order order = mock(Order.class);
+
         Delivery delivery = createDelivery(orderId, DeliveryStatus.ARRIVED); // 배송완료 상태
         List<Delivery> mockDeliveries = List.of(delivery);
 
-        given(deliveryRepository.findAllByOrderId(orderId)).willReturn(mockDeliveries);
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(order.getDeliveries()).willReturn(mockDeliveries);
 
         // when & then
         assertThatThrownBy(() -> deliveryService.cancelDelivery(event))

--- a/src/test/java/com/example/i_commerce/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/service/OrderServiceTest.java
@@ -20,10 +20,12 @@ import com.example.i_commerce.domain.order.repository.OrderRepository;
 import com.example.i_commerce.domain.order.repository.PaymentRepository;
 import com.example.i_commerce.domain.order.service.dto.CreateOrderRequest;
 import com.example.i_commerce.domain.order.service.dto.CreateOrderRequest.OrderItemDto;
+import com.example.i_commerce.domain.order.service.dto.CreateOrderResponse;
 import com.example.i_commerce.domain.order.service.dto.OrderDetailResponse;
 import com.example.i_commerce.domain.product.entity.Product;
 import com.example.i_commerce.domain.product.entity.ProductItem;
 import com.example.i_commerce.domain.product.exception.ProductErrorCode;
+import com.example.i_commerce.domain.product.facade.StockFacade;
 import com.example.i_commerce.domain.product.repository.ProductItemRepository;
 import com.example.i_commerce.global.common.response.ApiResponse;
 import com.example.i_commerce.global.exception.AppException;
@@ -58,6 +60,9 @@ class OrderServiceTest {
 
     @Mock
     OrderProductRepository orderProductRepository;
+
+    @Mock
+    StockFacade stockFacade;
 
     @InjectMocks
     OrderService orderService;
@@ -128,7 +133,7 @@ class OrderServiceTest {
         given(paymentRepository.save(any()))
                 .willAnswer(invocation -> invocation.getArgument(0));
 
-        ApiResponse<?> response = orderService.createOrder(OrderFixture.MEMBER_ID, dto);
+        ApiResponse<CreateOrderResponse> response = orderService.createOrder(OrderFixture.MEMBER_ID, dto);
 
         assertEquals("SUCCESS", response.code());
 
@@ -177,7 +182,7 @@ class OrderServiceTest {
 
         // then
         assertNotNull(response);
-        assertEquals(response.paymentInfo().paymentId(), 2L);
+        assertEquals(2L, response.paymentInfo().paymentId());
     }
 
     @Test

--- a/src/test/java/com/example/i_commerce/domain/order/service/PaymentServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/service/PaymentServiceTest.java
@@ -13,7 +13,7 @@ import com.example.i_commerce.domain.order.entity.Order;
 import com.example.i_commerce.domain.order.entity.Payment;
 import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
 import com.example.i_commerce.domain.order.entity.emuns.PaymentStatus;
-import com.example.i_commerce.domain.order.event.dto.PaymentCompletedEvent;
+import com.example.i_commerce.domain.order.event.dto.PaymentApprovedEvent;
 import com.example.i_commerce.domain.order.exception.PaymentErrorCode;
 import com.example.i_commerce.domain.order.repository.PaymentRepository;
 import com.example.i_commerce.domain.order.service.dto.PaymentCancelRequest;
@@ -100,7 +100,7 @@ public class PaymentServiceTest {
         assertThat(payment.getPayStatus()).isEqualTo(PaymentStatus.PAID);
         assertThat(payment.getCancelableAmount()).isEqualTo(dto.amount());
         verify(order).changeOrderStatus(OrderStatus.CONFIRMED);
-        verify(publisher).publishEvent(any(PaymentCompletedEvent.class));
+        verify(publisher).publishEvent(any(PaymentApprovedEvent.class));
     }
 
     @Test
@@ -151,7 +151,7 @@ public class PaymentServiceTest {
         assertThat(payment.getPayStatus()).isEqualTo(PaymentStatus.CANCELLED);
         assertThat(payment.getCancelableAmount()).isEqualTo(0);
         verify(order).changeOrderStatus(OrderStatus.CANCELLED);
-        verify(publisher).publishEvent(any(PaymentCompletedEvent.class));
+        verify(publisher).publishEvent(any(PaymentApprovedEvent.class));
     }
 
     @Test

--- a/src/test/java/com/example/i_commerce/domain/order/service/PaymentServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/service/PaymentServiceTest.java
@@ -14,10 +14,12 @@ import com.example.i_commerce.domain.order.entity.Payment;
 import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
 import com.example.i_commerce.domain.order.entity.emuns.PaymentStatus;
 import com.example.i_commerce.domain.order.event.dto.PaymentApprovedEvent;
+import com.example.i_commerce.domain.order.event.dto.PaymentStatusChangedEvent;
 import com.example.i_commerce.domain.order.exception.PaymentErrorCode;
 import com.example.i_commerce.domain.order.repository.PaymentRepository;
 import com.example.i_commerce.domain.order.service.dto.PaymentCancelRequest;
 import com.example.i_commerce.domain.order.service.dto.PaymentConfirmRequest;
+import com.example.i_commerce.domain.product.facade.StockFacade;
 import com.example.i_commerce.global.exception.AppException;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,7 +49,10 @@ public class PaymentServiceTest {
     RestTemplate restTemplate;
 
     @Mock
-    private ApplicationEventPublisher publisher;
+    ApplicationEventPublisher publisher;
+
+    @Mock
+    StockFacade stockFacade;
 
     @InjectMocks
     PaymentService paymentService;
@@ -70,10 +75,14 @@ public class PaymentServiceTest {
     @Test
     @DisplayName("결제 상태가 READY가 아니면 예외가 발생한다.")
     void getPaymentDetails_fail_invalidPaymentStatus() {
-        Payment payment = Payment.builder().payStatus(PaymentStatus.PAID).build();
+        Long userId = 1L;
+
+        ReflectionTestUtils.setField(payment, "payStatus", PaymentStatus.PAID);
+
+        given(order.getUserId()).willReturn(userId);
         given(paymentRepository.findById(anyLong())).willReturn(Optional.of(payment));
 
-        AppException e = assertThrows(AppException.class, () -> paymentService.getPaymentDetails(1L));
+        AppException e = assertThrows(AppException.class, () -> paymentService.getPaymentDetails(userId, 1L));
         Assertions.assertEquals("INVALID_PAYMENT_STATUS", e.getErrorCode().toString());
     }
 
@@ -151,7 +160,7 @@ public class PaymentServiceTest {
         assertThat(payment.getPayStatus()).isEqualTo(PaymentStatus.CANCELLED);
         assertThat(payment.getCancelableAmount()).isEqualTo(0);
         verify(order).changeOrderStatus(OrderStatus.CANCELLED);
-        verify(publisher).publishEvent(any(PaymentApprovedEvent.class));
+        verify(publisher).publishEvent(any(PaymentStatusChangedEvent.class));
     }
 
     @Test


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
closed #62 

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
- 이커머스 관점의 주문 생성 시점 선 재고 차감 및 롤백 구현
  - OrderService.createOrder 시점에 상품 도메인의 stockFacade.deductStock()을 동기식으로 호출하도록 구현했습니다.
  - 다중 상품 주문 중 단 하나의 상품이라도 재고가 부족해 예외가 발생하면 상위 @Transactional에 의해 생성 중이던 주문서까지 원자적으로 자동 롤백되도록 구축했습니다.
 
- 결제 완료 건에 대한 결제 취소 후 재고 복구 프로세스 연동
  - 이전 브랜치에 구현된 배송 상태 검증 흐름을 기반으로, 토스페이먼츠 결제 취소 API 성공 후 상품 도메인의 stockFacade.rollbackStocks()를 호출하여 차감되었던 상품 재고를 원복하는 연동 로직을 완성했습니다.

## 😅 Uncompleted Tasks
[//]: # (없다면 N/A)
- 토스 API 타임아웃 처리 및 내부 DB 정합성 불일치 완벽 방어 흐름 구현 (별도 브랜치로 분리하여 함께 해결 예정)
  - restTemplate 통신 중 타임아웃 발생 시, 토스 결제 상태 단건 조회 API를 재호출하여 실제 취소 여부를 교차 검증하는 흐름을 개발해야 합니다.
  - 토스 API가 최종 성공한 이후 내부 재고 복구(stockFacade.rollbackStocks)나 상태 변경 중 일시적인 DB 장애가 발생했을 때, 트랜잭션이 통째로 롤백되어 돈만 환불되고 시스템은 결제 완료로 남는 최악의 불일치를 막기 위한 내부 DB 반영용 try-catch 구조 격리 및 비상 알림/로그 수집 프로세스를 연계하여 함께 구현할 예정입니다.

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
본인 테스트코드에 에러 없는지 확인해주세요!