### PR TITLE
Feat: s3 업로드, 삭제 기능 구현

### DIFF
--- a/src/main/java/com/example/i_commerce/domain/order/event/dto/DeliveryCancelRequestEvent.java
+++ b/src/main/java/com/example/i_commerce/domain/order/event/dto/DeliveryCancelRequestEvent.java
@@ -1,4 +1,4 @@
-package com.example.i_commerce.domain.order.service.dto;
+package com.example.i_commerce.domain.order.event.dto;
 
 public record DeliveryCancelRequestEvent(
         Long orderId

--- a/src/main/java/com/example/i_commerce/domain/order/event/dto/PaymentApprovedEvent.java
+++ b/src/main/java/com/example/i_commerce/domain/order/event/dto/PaymentApprovedEvent.java
@@ -1,0 +1,6 @@
+package com.example.i_commerce.domain.order.event.dto;
+
+public record PaymentApprovedEvent(
+        Long orderId
+) {
+}

--- a/src/main/java/com/example/i_commerce/domain/order/event/dto/PaymentStatusChangedEvent.java
+++ b/src/main/java/com/example/i_commerce/domain/order/event/dto/PaymentStatusChangedEvent.java
@@ -3,7 +3,7 @@ package com.example.i_commerce.domain.order.event.dto;
 import com.example.i_commerce.domain.order.entity.Payment;
 import com.example.i_commerce.domain.order.entity.emuns.PaymentStatus;
 
-public record PaymentCompletedEvent(
+public record PaymentStatusChangedEvent(
         Payment payment,
         PaymentStatus previousStatus,
         String reason,
@@ -11,4 +11,6 @@ public record PaymentCompletedEvent(
         String pgTid,
         String rawData
 ) {
+
+
 }

--- a/src/main/java/com/example/i_commerce/domain/order/event/listener/DeliveryListener.java
+++ b/src/main/java/com/example/i_commerce/domain/order/event/listener/DeliveryListener.java
@@ -1,12 +1,8 @@
 package com.example.i_commerce.domain.order.event.listener;
 
-import com.example.i_commerce.domain.order.entity.Delivery;
-import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
-import com.example.i_commerce.domain.order.event.dto.PaymentCompletedEvent;
+import com.example.i_commerce.domain.order.event.dto.PaymentApprovedEvent;
 import com.example.i_commerce.domain.order.service.DeliveryService;
-import com.example.i_commerce.domain.order.service.dto.DeliveryCancelRequestEvent;
-import com.example.i_commerce.global.exception.AppException;
-import java.util.List;
+import com.example.i_commerce.domain.order.event.dto.DeliveryCancelRequestEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -22,7 +18,7 @@ public class DeliveryListener {
     private final DeliveryService deliveryService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handlePaymentCompleted(PaymentCompletedEvent event) {
+    public void handlePaymentCompleted(PaymentApprovedEvent event) {
         deliveryService.createDelivery(event);
     }
 

--- a/src/main/java/com/example/i_commerce/domain/order/event/listener/PaymentLogListener.java
+++ b/src/main/java/com/example/i_commerce/domain/order/event/listener/PaymentLogListener.java
@@ -1,6 +1,6 @@
 package com.example.i_commerce.domain.order.event.listener;
 
-import com.example.i_commerce.domain.order.event.dto.PaymentCompletedEvent;
+import com.example.i_commerce.domain.order.event.dto.PaymentStatusChangedEvent;
 import com.example.i_commerce.domain.order.service.PaymentHistoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,7 +16,7 @@ public class PaymentLogListener {
     private final PaymentHistoryService paymentHistoryService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void createPaymentHistoryRequest(PaymentCompletedEvent event) {
+    public void createPaymentHistoryRequest(PaymentStatusChangedEvent event) {
         paymentHistoryService.createPaymentHistory(event);
     }
 }

--- a/src/main/java/com/example/i_commerce/domain/order/service/DeliveryService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/DeliveryService.java
@@ -4,12 +4,12 @@ import com.example.i_commerce.domain.order.entity.Delivery;
 import com.example.i_commerce.domain.order.entity.Order;
 import com.example.i_commerce.domain.order.entity.OrderProduct;
 import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
-import com.example.i_commerce.domain.order.event.dto.PaymentCompletedEvent;
+import com.example.i_commerce.domain.order.event.dto.PaymentApprovedEvent;
 import com.example.i_commerce.domain.order.exception.OrderErrorCode;
 import com.example.i_commerce.domain.order.exception.PaymentErrorCode;
 import com.example.i_commerce.domain.order.repository.DeliveryRepository;
 import com.example.i_commerce.domain.order.repository.OrderRepository;
-import com.example.i_commerce.domain.order.service.dto.DeliveryCancelRequestEvent;
+import com.example.i_commerce.domain.order.event.dto.DeliveryCancelRequestEvent;
 import com.example.i_commerce.domain.product.entity.ProductItem;
 import com.example.i_commerce.domain.product.repository.ProductItemRepository;
 import com.example.i_commerce.global.exception.AppException;
@@ -18,10 +18,12 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class DeliveryService {
@@ -31,9 +33,9 @@ public class DeliveryService {
     private final ProductItemRepository productItemRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void createDelivery(PaymentCompletedEvent event) {
+    public void createDelivery(PaymentApprovedEvent event) {
 
-        Order order = orderRepository.findById(event.payment().getOrder().getId()).orElseThrow(() -> new AppException(OrderErrorCode.ORDER_NOT_FOUND));
+        Order order = orderRepository.findById(event.orderId()).orElseThrow(() -> new AppException(OrderErrorCode.ORDER_NOT_FOUND));
 
         List<Long> productIds = order.getOrderProducts().stream()
                 .map(OrderProduct::getProductSkuId).toList();
@@ -61,8 +63,10 @@ public class DeliveryService {
 
     }
 
+    @Transactional
     public void cancelDelivery(DeliveryCancelRequestEvent event) {
-        List<Delivery> deliveries = deliveryRepository.findAllByOrderId(event.orderId());
+        Order order = orderRepository.findById(event.orderId()).orElseThrow(() -> new AppException(OrderErrorCode.ORDER_NOT_FOUND));
+        List<Delivery> deliveries = order.getDeliveries();
 
         for (Delivery delivery : deliveries) {
             if (delivery.getDeliveryStatus() == DeliveryStatus.SHIPPING ||

--- a/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
@@ -23,6 +23,8 @@ import com.example.i_commerce.domain.order.service.dto.OrderDetailResponse.Payme
 import com.example.i_commerce.domain.order.service.dto.OrderSummaryResponse;
 import com.example.i_commerce.domain.product.entity.ProductItem;
 import com.example.i_commerce.domain.product.exception.ProductErrorCode;
+import com.example.i_commerce.domain.product.facade.StockFacade;
+import com.example.i_commerce.domain.product.facade.dto.StockDeductCommand;
 import com.example.i_commerce.domain.product.repository.ProductItemRepository;
 import com.example.i_commerce.global.common.response.ApiResponse;
 import com.example.i_commerce.global.exception.AppException;
@@ -47,6 +49,7 @@ public class OrderService {
     private final PaymentRepository paymentRepository;
     private final DeliveryAddressService deliveryAddressService;
     private final OrderProductRepository orderProductRepository;
+    private final StockFacade stockFacade;
 
     @Transactional
     public ApiResponse<CreateOrderResponse> createOrder(Long memberId, CreateOrderRequest dto) {
@@ -98,6 +101,16 @@ public class OrderService {
         orderProducts.forEach(orderProduct -> orderProduct.assignOrder(order));
 
         orderRepository.save(order);
+
+        List<StockDeductCommand> stockDeductCommands = dto.items().stream()
+                .map(orderItemDto ->
+                        new StockDeductCommand(
+                                orderItemDto.productId(),
+                                orderItemDto.quantity(),
+                                order.getId()))
+                .toList();
+
+        stockFacade.deductStock(stockDeductCommands);
 
         Payment payment = paymentRepository.save(Payment.builder()
                 .order(order)

--- a/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
@@ -119,7 +119,6 @@ public class OrderService {
                 .payStatus(PaymentStatus.READY)
                 .build());
 
-       //TODO : 재고 차감
         String firstProductName = order.getOrderProducts().getFirst().getProductName();
 
         return ApiResponse.success(CreateOrderResponse.of(order, payment, firstProductName));

--- a/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
@@ -118,8 +118,8 @@ public class OrderService {
                 .cancelableAmount(0)
                 .payStatus(PaymentStatus.READY)
                 .build());
-
-        String firstProductName = order.getOrderProducts().getFirst().getProductName();
+        
+        String firstProductName = order.getOrderProducts().stream().findFirst().map(OrderProduct::getProductName).orElse("");
 
         return ApiResponse.success(CreateOrderResponse.of(order, payment, firstProductName));
 

--- a/src/main/java/com/example/i_commerce/domain/order/service/PaymentHistoryService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/PaymentHistoryService.java
@@ -3,9 +3,8 @@ package com.example.i_commerce.domain.order.service;
 import com.example.i_commerce.domain.order.entity.Order;
 import com.example.i_commerce.domain.order.entity.Payment;
 import com.example.i_commerce.domain.order.entity.PaymentHistory;
-import com.example.i_commerce.domain.order.event.dto.PaymentCompletedEvent;
+import com.example.i_commerce.domain.order.event.dto.PaymentStatusChangedEvent;
 import com.example.i_commerce.domain.order.repository.PaymentHistoryRepository;
-import com.example.i_commerce.domain.order.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -18,7 +17,7 @@ public class PaymentHistoryService {
     private final PaymentHistoryRepository paymentHistoryRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void createPaymentHistory(PaymentCompletedEvent event) {
+    public void createPaymentHistory(PaymentStatusChangedEvent event) {
         Payment payment = event.payment();
         Order order = payment.getOrder();
         paymentHistoryRepository.save(

--- a/src/main/java/com/example/i_commerce/domain/order/service/PaymentService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/PaymentService.java
@@ -1,21 +1,25 @@
 package com.example.i_commerce.domain.order.service;
 
+import com.example.i_commerce.domain.order.entity.Delivery;
 import com.example.i_commerce.domain.order.entity.Order;
 import com.example.i_commerce.domain.order.entity.Payment;
 import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
 import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
 import com.example.i_commerce.domain.order.entity.emuns.PaymentStatus;
-import com.example.i_commerce.domain.order.event.dto.PaymentCompletedEvent;
+import com.example.i_commerce.domain.order.event.dto.DeliveryCancelRequestEvent;
+import com.example.i_commerce.domain.order.event.dto.PaymentApprovedEvent;
+import com.example.i_commerce.domain.order.event.dto.PaymentStatusChangedEvent;
 import com.example.i_commerce.domain.order.exception.PaymentErrorCode;
 import com.example.i_commerce.domain.order.repository.PaymentRepository;
-import com.example.i_commerce.domain.order.service.dto.DeliveryCancelRequestEvent;
 import com.example.i_commerce.domain.order.service.dto.PaymentCancelRequest;
 import com.example.i_commerce.domain.order.service.dto.PaymentConfirmRequest;
 import com.example.i_commerce.domain.order.service.dto.PaymentDetailResponse;
+import com.example.i_commerce.domain.product.facade.StockFacade;
 import com.example.i_commerce.global.exception.AppException;
 import jakarta.annotation.PostConstruct;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +43,7 @@ public class PaymentService {
     private final PaymentRepository paymentRepository;
     private final ApplicationEventPublisher publisher;
     private final RestTemplate restTemplate;
+    private final StockFacade stockFacade;
 
     @Value("${toss.secretKey}")
     private String SECRET_KEY;
@@ -72,7 +77,7 @@ public class PaymentService {
     @Transactional
     public void confirmPayment(PaymentConfirmRequest dto) {
         if (dto.tossOrderId() == null || !dto.tossOrderId().contains("_")) {
-            throw new AppException(PaymentErrorCode.INVALID_PAYMENT_REQUEST); // 400 Bad Request
+            throw new AppException(PaymentErrorCode.INVALID_PAYMENT_REQUEST);
         }
         Long paymentId = Long.valueOf(dto.tossOrderId().split("_")[1]);
         Payment payment = paymentRepository.findById(paymentId)
@@ -112,7 +117,9 @@ public class PaymentService {
                 payment.completePayment(pgTid);
                 payment.getOrder().changeOrderStatus(OrderStatus.CONFIRMED);
 
-                publisher.publishEvent(new PaymentCompletedEvent(
+                publisher.publishEvent(new PaymentApprovedEvent(payment.getOrder().getId()));
+
+                publisher.publishEvent(new PaymentStatusChangedEvent(
                         payment,
                         previousStatus,
                         "결제 완료",
@@ -134,8 +141,6 @@ public class PaymentService {
         Payment payment = paymentRepository.findById(dto.paymentId())
                 .orElseThrow(() -> new AppException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
-
-
         if(!Objects.equals(dto.paymentKey(), payment.getPgTid())) {
             throw new AppException(PaymentErrorCode.INVALID_PAYMENT_KEY);
         }
@@ -149,6 +154,27 @@ public class PaymentService {
         }
 
         publisher.publishEvent(new DeliveryCancelRequestEvent(payment.getOrder().getId()));
+        Order order = payment.getOrder();
+//        List<Delivery> deliveries = order.getDeliveries();
+//        log.info("--- 반복문 시작 전 ---");
+//        for (Delivery d : deliveries) {
+//            // d.hashCode()는 equals/hashCode가 없으므로 객체의 메모리 주소 기반 값을 리턴합니다.
+//            log.info("Delivery ID: {}, 객체 주소값: {}, 상태: {}", d.getId(), System.identityHashCode(d), d.getDeliveryStatus());
+//        }
+//
+//        for (Delivery delivery : deliveries) {
+//            if (delivery.getDeliveryStatus() == DeliveryStatus.SHIPPING ||
+//                    delivery.getDeliveryStatus() == DeliveryStatus.ARRIVED) {
+//                throw new AppException(PaymentErrorCode.PAYMENT_CANCEL_IMPOSSIBLE_ALREADY_SHIPPED);
+//            }
+//
+//            delivery.changeDeliveryStatus(DeliveryStatus.CANCELLED);
+//        }
+//
+//        log.info("--- 반복문 종료 후 ---");
+//        for (Delivery d : payment.getOrder().getDeliveries()) {
+//            log.info("Delivery ID: {}, 객체 주소값: {}, 상태: {}", d.getId(), System.identityHashCode(d), d.getDeliveryStatus());
+//        }
 
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Basic " + encodedKey);
@@ -173,10 +199,11 @@ public class PaymentService {
                 String pgTid = (String) response.getBody().get("paymentKey");
 
                 payment.cancelPayment(dto.cancelAmount());
-                payment.getOrder().changeOrderStatus(OrderStatus.CANCELLED);
-                //TODO: 재고 rollback
+                order.changeOrderStatus(OrderStatus.CANCELLED);
 
-                publisher.publishEvent(new PaymentCompletedEvent(
+                stockFacade.rollbackStocks(order.getId());
+
+                publisher.publishEvent(new PaymentStatusChangedEvent(
                         payment,
                         previousStatus,
                         dto.cancelReason(),

--- a/src/main/java/com/example/i_commerce/domain/order/service/PaymentService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/PaymentService.java
@@ -154,32 +154,12 @@ public class PaymentService {
         }
 
         publisher.publishEvent(new DeliveryCancelRequestEvent(payment.getOrder().getId()));
+
         Order order = payment.getOrder();
-//        List<Delivery> deliveries = order.getDeliveries();
-//        log.info("--- 반복문 시작 전 ---");
-//        for (Delivery d : deliveries) {
-//            // d.hashCode()는 equals/hashCode가 없으므로 객체의 메모리 주소 기반 값을 리턴합니다.
-//            log.info("Delivery ID: {}, 객체 주소값: {}, 상태: {}", d.getId(), System.identityHashCode(d), d.getDeliveryStatus());
-//        }
-//
-//        for (Delivery delivery : deliveries) {
-//            if (delivery.getDeliveryStatus() == DeliveryStatus.SHIPPING ||
-//                    delivery.getDeliveryStatus() == DeliveryStatus.ARRIVED) {
-//                throw new AppException(PaymentErrorCode.PAYMENT_CANCEL_IMPOSSIBLE_ALREADY_SHIPPED);
-//            }
-//
-//            delivery.changeDeliveryStatus(DeliveryStatus.CANCELLED);
-//        }
-//
-//        log.info("--- 반복문 종료 후 ---");
-//        for (Delivery d : payment.getOrder().getDeliveries()) {
-//            log.info("Delivery ID: {}, 객체 주소값: {}, 상태: {}", d.getId(), System.identityHashCode(d), d.getDeliveryStatus());
-//        }
 
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Basic " + encodedKey);
         headers.setContentType(MediaType.APPLICATION_JSON);
-
 
         Map<String, Object> params = new HashMap<>();
         params.put("cancelReason", dto.cancelReason());

--- a/src/main/java/com/example/i_commerce/global/exception/common/CommonErrorCode.java
+++ b/src/main/java/com/example/i_commerce/global/exception/common/CommonErrorCode.java
@@ -9,9 +9,14 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CommonErrorCode implements ErrorCode {
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "COM-40001", "잘못된 입력값입니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "COM-40301", "접근 권한이 없습니다."),
+    INVALID_MULTIPART_FILE(HttpStatus.BAD_REQUEST, "COM-40002", "멀티파트 파일이 유효하지 않습니다."),
+
     INVALID_PERMISSION(HttpStatus.UNAUTHORIZED, "COM-40101", "권한이 없습니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COM-50001", "서버 내부 에러가 발생했습니다."),
+
+    FORBIDDEN(HttpStatus.FORBIDDEN, "COM-40301", "접근 권한이 없습니다."),
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COM-50001", "서버 내부 에러가 발생했습니다.");
+
 
     ;
 

--- a/src/main/java/com/example/i_commerce/global/exception/common/CommonErrorCode.java
+++ b/src/main/java/com/example/i_commerce/global/exception/common/CommonErrorCode.java
@@ -15,8 +15,8 @@ public enum CommonErrorCode implements ErrorCode {
 
     FORBIDDEN(HttpStatus.FORBIDDEN, "COM-40301", "접근 권한이 없습니다."),
 
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COM-50001", "서버 내부 에러가 발생했습니다.");
-
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COM-50001", "서버 내부 에러가 발생했습니다."),
+    S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "COM-50002", "AWS S3 파일 업로드 중 오류가 발생했습니다.")
 
     ;
 

--- a/src/main/java/com/example/i_commerce/global/s3/config/S3Config.java
+++ b/src/main/java/com/example/i_commerce/global/s3/config/S3Config.java
@@ -1,4 +1,4 @@
-package com.example.i_commerce.global.config;
+package com.example.i_commerce.global.s3.config;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/example/i_commerce/global/s3/controller/GlobalImageController.java
+++ b/src/main/java/com/example/i_commerce/global/s3/controller/GlobalImageController.java
@@ -26,7 +26,7 @@ public class GlobalImageController {
     @PreAuthorize("hasRole('MEMBER')")
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<String> uploadImage(@RequestParam("file") MultipartFile file) {
-        String fileUrl = s3ImageService.uploadImage(file);
+        String fileUrl = s3ImageService.uploadImage(file, "review");
         return ApiResponse.success(fileUrl); // 성공 시 S3 URL 문자열 반환
     }
 

--- a/src/main/java/com/example/i_commerce/global/s3/controller/GlobalImageController.java
+++ b/src/main/java/com/example/i_commerce/global/s3/controller/GlobalImageController.java
@@ -1,0 +1,40 @@
+package com.example.i_commerce.global.s3.controller;
+
+import com.example.i_commerce.global.common.response.ApiResponse;
+import com.example.i_commerce.global.s3.service.S3ImageService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1/images")
+@Tag(name = "GlobalImageController", description = "이미  지 업로드 및 삭제 테스트 용 API")
+@RequiredArgsConstructor
+public class GlobalImageController {
+
+    private final S3ImageService s3ImageService;
+
+
+    @PreAuthorize("hasRole('MEMBER')")
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<String> uploadImage(@RequestParam("file") MultipartFile file) {
+        String fileUrl = s3ImageService.uploadImage(file);
+        return ApiResponse.success(fileUrl); // 성공 시 S3 URL 문자열 반환
+    }
+
+    @PreAuthorize("hasRole('MEMBER')")
+    @DeleteMapping("/delete")
+    public ApiResponse<String> deleteImage(@RequestParam("fileUrl") String fileUrl) {
+        s3ImageService.deleteImage(fileUrl);
+        return ApiResponse.success("S3 파일 삭제 완료");
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/global/s3/service/S3ImageService.java
+++ b/src/main/java/com/example/i_commerce/global/s3/service/S3ImageService.java
@@ -4,11 +4,15 @@ import com.example.i_commerce.global.common.response.ApiResponse;
 import com.example.i_commerce.global.exception.AppException;
 import com.example.i_commerce.global.exception.common.CommonErrorCode;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
@@ -23,13 +27,13 @@ public class S3ImageService {
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucket;
 
-    public String uploadImage(MultipartFile file) {
+    public String uploadImage(MultipartFile file, String folder) {
         if(file.isEmpty()) {
             throw new AppException(CommonErrorCode.INVALID_MULTIPART_FILE);
         }
 
         String originalFilename = file.getOriginalFilename();
-        String s3FileName = generateS3FileName(originalFilename);
+        String s3FileName = folder + "/" + generateS3FileName(originalFilename);
 
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
@@ -43,8 +47,8 @@ public class S3ImageService {
 
             return s3Client.utilities().getUrl(builder -> builder.bucket(bucket).key(s3FileName)).toExternalForm();
 
-        } catch (IOException e) {
-            throw new RuntimeException("S3 파일 업로드 중 오류가 발생했습니다.", e);
+        } catch (IOException | SdkException e) {
+            throw new AppException(CommonErrorCode.S3_UPLOAD_FAILED);
         }
     }
 
@@ -64,12 +68,28 @@ public class S3ImageService {
     }
 
     private String generateS3FileName(String originalFilename) {
-        String ext = originalFilename.substring(originalFilename.lastIndexOf("."));
-        return UUID.randomUUID().toString() + ext;
+        int dotIndex = (originalFilename != null) ? originalFilename.lastIndexOf(".") : -1;
+        String ext = (dotIndex != -1) ? originalFilename.substring(dotIndex) : "";
+        return UUID.randomUUID() + ext;
     }
 
     private String extractFileNameFromUrl(String fileUrl) {
-        return fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
+
+        try {
+            URI uri = new URI(fileUrl);
+            String path = uri.getPath();
+
+            String decodedUri = URLDecoder.decode(path, StandardCharsets.UTF_8);
+
+            if(decodedUri.startsWith("/")) {
+                decodedUri = decodedUri.substring(1);
+            }
+
+            return decodedUri;
+
+        } catch (Exception e) {
+            throw new AppException(CommonErrorCode.INVALID_INPUT_VALUE);
+        }
     }
 
 }

--- a/src/main/java/com/example/i_commerce/global/s3/service/S3ImageService.java
+++ b/src/main/java/com/example/i_commerce/global/s3/service/S3ImageService.java
@@ -47,6 +47,7 @@ public class S3ImageService {
             throw new RuntimeException("S3 파일 업로드 중 오류가 발생했습니다.", e);
         }
     }
+
     public void deleteImage(String fileUrl) {
         if (fileUrl == null || fileUrl.isEmpty()) {
             return;

--- a/src/main/java/com/example/i_commerce/global/s3/service/S3ImageService.java
+++ b/src/main/java/com/example/i_commerce/global/s3/service/S3ImageService.java
@@ -1,0 +1,74 @@
+package com.example.i_commerce.global.s3.service;
+
+import com.example.i_commerce.global.common.response.ApiResponse;
+import com.example.i_commerce.global.exception.AppException;
+import com.example.i_commerce.global.exception.common.CommonErrorCode;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+public class S3ImageService {
+
+    private final S3Client s3Client;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadImage(MultipartFile file) {
+        if(file.isEmpty()) {
+            throw new AppException(CommonErrorCode.INVALID_MULTIPART_FILE);
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        String s3FileName = generateS3FileName(originalFilename);
+
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(s3FileName)
+                    .contentType(file.getContentType())
+                    .build();
+
+            s3Client.putObject(putObjectRequest,
+                    RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+            return s3Client.utilities().getUrl(builder -> builder.bucket(bucket).key(s3FileName)).toExternalForm();
+
+        } catch (IOException e) {
+            throw new RuntimeException("S3 파일 업로드 중 오류가 발생했습니다.", e);
+        }
+    }
+    public void deleteImage(String fileUrl) {
+        if (fileUrl == null || fileUrl.isEmpty()) {
+            return;
+        }
+
+        String s3FileName = extractFileNameFromUrl(fileUrl);
+
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(s3FileName)
+                .build();
+
+        s3Client.deleteObject(deleteObjectRequest);
+    }
+
+    private String generateS3FileName(String originalFilename) {
+        String ext = originalFilename.substring(originalFilename.lastIndexOf("."));
+        return UUID.randomUUID().toString() + ext;
+    }
+
+    private String extractFileNameFromUrl(String fileUrl) {
+        return fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/global/swagger/SwaggerConfig.java
+++ b/src/main/java/com/example/i_commerce/global/swagger/SwaggerConfig.java
@@ -90,4 +90,15 @@ public class SwaggerConfig {
             .addOpenApiCustomizer(securityCustomizer())
             .build();
     }
+
+    @Bean
+    public GroupedOpenApi s3ImageApi() {
+        return GroupedOpenApi.builder()
+                .group("s3Image-test")
+                .pathsToMatch(
+                        "/api/v1/images/**"
+                )
+                .addOpenApiCustomizer(securityCustomizer())
+                .build();
+    }
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -40,6 +40,11 @@ spring:
       stack:
         auto: false
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 20MB
+
 #임시적인 JWT 설정 추후 필수 삭제
 jwt:
   # chatserversecretaccesstokenchatserversecretaccesstokenchatserversecretaccesstoken

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -37,6 +37,11 @@ spring:
       stack:
         auto: false
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 20MB
+
 #임시적인 JWT 설정 추후 필수 삭제
 jwt:
   # chatserversecretaccesstokenchatserversecretaccesstokenchatserversecretaccesstoken

--- a/src/test/java/com/example/i_commerce/domain/order/service/DeliveryServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/service/DeliveryServiceTest.java
@@ -15,11 +15,11 @@ import com.example.i_commerce.domain.order.entity.Order;
 import com.example.i_commerce.domain.order.entity.OrderProduct;
 import com.example.i_commerce.domain.order.entity.Payment;
 import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
-import com.example.i_commerce.domain.order.event.dto.PaymentCompletedEvent;
+import com.example.i_commerce.domain.order.event.dto.PaymentApprovedEvent;
 import com.example.i_commerce.domain.order.exception.PaymentErrorCode;
 import com.example.i_commerce.domain.order.repository.DeliveryRepository;
 import com.example.i_commerce.domain.order.repository.OrderRepository;
-import com.example.i_commerce.domain.order.service.dto.DeliveryCancelRequestEvent;
+import com.example.i_commerce.domain.order.event.dto.DeliveryCancelRequestEvent;
 import com.example.i_commerce.domain.product.entity.Product;
 import com.example.i_commerce.domain.product.entity.ProductItem;
 import com.example.i_commerce.domain.product.repository.ProductItemRepository;
@@ -72,7 +72,7 @@ class DeliveryServiceTest {
         given(order.getOrderProducts()).willReturn(List.of(item1, item2));
 
         // Event 모킹
-        PaymentCompletedEvent event = mock(PaymentCompletedEvent.class);
+        PaymentApprovedEvent event = mock(PaymentApprovedEvent.class);
         Payment payment = mock(Payment.class);
         given(event.payment()).willReturn(payment);
         given(payment.getOrder()).willReturn(order);
@@ -114,7 +114,7 @@ class DeliveryServiceTest {
     @DisplayName("주문 정보가 없으면 AppException이 발생한다")
     void createDelivery_OrderNotFound() {
         // given
-        PaymentCompletedEvent event = mock(PaymentCompletedEvent.class);
+        PaymentApprovedEvent event = mock(PaymentApprovedEvent.class);
         Payment payment = mock(Payment.class);
         Order order = mock(Order.class);
 

--- a/src/test/java/com/example/i_commerce/domain/order/service/DeliveryServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/service/DeliveryServiceTest.java
@@ -66,7 +66,6 @@ class DeliveryServiceTest {
         OrderProduct item1 = mock(OrderProduct.class);
         OrderProduct item2 = mock(OrderProduct.class);
 
-        given(order.getId()).willReturn(orderId);
         given(item1.getProductSkuId()).willReturn(skuId1);
         given(item2.getProductSkuId()).willReturn(skuId2);
         given(order.getOrderProducts()).willReturn(List.of(item1, item2));
@@ -74,8 +73,7 @@ class DeliveryServiceTest {
         // Event 모킹
         PaymentApprovedEvent event = mock(PaymentApprovedEvent.class);
         Payment payment = mock(Payment.class);
-        given(event.payment()).willReturn(payment);
-        given(payment.getOrder()).willReturn(order);
+        given(event.orderId()).willReturn(orderId);
 
         // Repository 동작 정의
         given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
@@ -118,9 +116,7 @@ class DeliveryServiceTest {
         Payment payment = mock(Payment.class);
         Order order = mock(Order.class);
 
-        given(event.payment()).willReturn(payment);
-        given(payment.getOrder()).willReturn(order);
-        given(order.getId()).willReturn(1L);
+        given(event.orderId()).willReturn(1L);
         given(orderRepository.findById(1L)).willReturn(Optional.empty());
 
         // when & then
@@ -135,12 +131,14 @@ class DeliveryServiceTest {
         Long orderId = 1L;
         DeliveryCancelRequestEvent event = new DeliveryCancelRequestEvent(orderId);
 
+        Order order = mock(Order.class);
         // 가상의 배송 전(READY) 객체 생성 (실제 엔티티 구현체에 맞게 빌더나 생성자 사용)
         Delivery delivery1 = createDelivery(orderId, DeliveryStatus.PREPARING);
         Delivery delivery2 = createDelivery(orderId, DeliveryStatus.PREPARING);
         List<Delivery> mockDeliveries = List.of(delivery1, delivery2);
 
-        given(deliveryRepository.findAllByOrderId(orderId)).willReturn(mockDeliveries);
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(order.getDeliveries()).willReturn(mockDeliveries);
 
         // when
         deliveryService.cancelDelivery(event);
@@ -157,12 +155,15 @@ class DeliveryServiceTest {
         Long orderId = 1L;
         DeliveryCancelRequestEvent event = new DeliveryCancelRequestEvent(orderId);
 
+        Order order = mock(Order.class);
+
         Delivery delivery1 = createDelivery(orderId, DeliveryStatus.PREPARING);
         Delivery delivery2 = createDelivery(orderId, DeliveryStatus.SHIPPING);
 
         List<Delivery> mockDeliveries = List.of(delivery1, delivery2);
 
-        given(deliveryRepository.findAllByOrderId(orderId)).willReturn(mockDeliveries);
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(order.getDeliveries()).willReturn(mockDeliveries);
 
         // when & then
         assertThatThrownBy(() -> deliveryService.cancelDelivery(event))
@@ -177,10 +178,13 @@ class DeliveryServiceTest {
         Long orderId = 1L;
         DeliveryCancelRequestEvent event = new DeliveryCancelRequestEvent(orderId);
 
+        Order order = mock(Order.class);
+
         Delivery delivery = createDelivery(orderId, DeliveryStatus.ARRIVED); // 배송완료 상태
         List<Delivery> mockDeliveries = List.of(delivery);
 
-        given(deliveryRepository.findAllByOrderId(orderId)).willReturn(mockDeliveries);
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(order.getDeliveries()).willReturn(mockDeliveries);
 
         // when & then
         assertThatThrownBy(() -> deliveryService.cancelDelivery(event))

--- a/src/test/java/com/example/i_commerce/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/service/OrderServiceTest.java
@@ -20,10 +20,12 @@ import com.example.i_commerce.domain.order.repository.OrderRepository;
 import com.example.i_commerce.domain.order.repository.PaymentRepository;
 import com.example.i_commerce.domain.order.service.dto.CreateOrderRequest;
 import com.example.i_commerce.domain.order.service.dto.CreateOrderRequest.OrderItemDto;
+import com.example.i_commerce.domain.order.service.dto.CreateOrderResponse;
 import com.example.i_commerce.domain.order.service.dto.OrderDetailResponse;
 import com.example.i_commerce.domain.product.entity.Product;
 import com.example.i_commerce.domain.product.entity.ProductItem;
 import com.example.i_commerce.domain.product.exception.ProductErrorCode;
+import com.example.i_commerce.domain.product.facade.StockFacade;
 import com.example.i_commerce.domain.product.repository.ProductItemRepository;
 import com.example.i_commerce.global.common.response.ApiResponse;
 import com.example.i_commerce.global.exception.AppException;
@@ -58,6 +60,9 @@ class OrderServiceTest {
 
     @Mock
     OrderProductRepository orderProductRepository;
+
+    @Mock
+    StockFacade stockFacade;
 
     @InjectMocks
     OrderService orderService;
@@ -128,7 +133,7 @@ class OrderServiceTest {
         given(paymentRepository.save(any()))
                 .willAnswer(invocation -> invocation.getArgument(0));
 
-        ApiResponse<?> response = orderService.createOrder(OrderFixture.MEMBER_ID, dto);
+        ApiResponse<CreateOrderResponse> response = orderService.createOrder(OrderFixture.MEMBER_ID, dto);
 
         assertEquals("SUCCESS", response.code());
 
@@ -177,7 +182,7 @@ class OrderServiceTest {
 
         // then
         assertNotNull(response);
-        assertEquals(response.paymentInfo().paymentId(), 2L);
+        assertEquals(2L, response.paymentInfo().paymentId());
     }
 
     @Test

--- a/src/test/java/com/example/i_commerce/domain/order/service/PaymentServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/service/PaymentServiceTest.java
@@ -13,7 +13,7 @@ import com.example.i_commerce.domain.order.entity.Order;
 import com.example.i_commerce.domain.order.entity.Payment;
 import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
 import com.example.i_commerce.domain.order.entity.emuns.PaymentStatus;
-import com.example.i_commerce.domain.order.event.dto.PaymentCompletedEvent;
+import com.example.i_commerce.domain.order.event.dto.PaymentApprovedEvent;
 import com.example.i_commerce.domain.order.exception.PaymentErrorCode;
 import com.example.i_commerce.domain.order.repository.PaymentRepository;
 import com.example.i_commerce.domain.order.service.dto.PaymentCancelRequest;
@@ -100,7 +100,7 @@ public class PaymentServiceTest {
         assertThat(payment.getPayStatus()).isEqualTo(PaymentStatus.PAID);
         assertThat(payment.getCancelableAmount()).isEqualTo(dto.amount());
         verify(order).changeOrderStatus(OrderStatus.CONFIRMED);
-        verify(publisher).publishEvent(any(PaymentCompletedEvent.class));
+        verify(publisher).publishEvent(any(PaymentApprovedEvent.class));
     }
 
     @Test
@@ -151,7 +151,7 @@ public class PaymentServiceTest {
         assertThat(payment.getPayStatus()).isEqualTo(PaymentStatus.CANCELLED);
         assertThat(payment.getCancelableAmount()).isEqualTo(0);
         verify(order).changeOrderStatus(OrderStatus.CANCELLED);
-        verify(publisher).publishEvent(any(PaymentCompletedEvent.class));
+        verify(publisher).publishEvent(any(PaymentApprovedEvent.class));
     }
 
     @Test

--- a/src/test/java/com/example/i_commerce/domain/order/service/PaymentServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/service/PaymentServiceTest.java
@@ -14,10 +14,12 @@ import com.example.i_commerce.domain.order.entity.Payment;
 import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
 import com.example.i_commerce.domain.order.entity.emuns.PaymentStatus;
 import com.example.i_commerce.domain.order.event.dto.PaymentApprovedEvent;
+import com.example.i_commerce.domain.order.event.dto.PaymentStatusChangedEvent;
 import com.example.i_commerce.domain.order.exception.PaymentErrorCode;
 import com.example.i_commerce.domain.order.repository.PaymentRepository;
 import com.example.i_commerce.domain.order.service.dto.PaymentCancelRequest;
 import com.example.i_commerce.domain.order.service.dto.PaymentConfirmRequest;
+import com.example.i_commerce.domain.product.facade.StockFacade;
 import com.example.i_commerce.global.exception.AppException;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,7 +49,10 @@ public class PaymentServiceTest {
     RestTemplate restTemplate;
 
     @Mock
-    private ApplicationEventPublisher publisher;
+    ApplicationEventPublisher publisher;
+
+    @Mock
+    StockFacade stockFacade;
 
     @InjectMocks
     PaymentService paymentService;
@@ -70,10 +75,14 @@ public class PaymentServiceTest {
     @Test
     @DisplayName("결제 상태가 READY가 아니면 예외가 발생한다.")
     void getPaymentDetails_fail_invalidPaymentStatus() {
-        Payment payment = Payment.builder().payStatus(PaymentStatus.PAID).build();
+        Long userId = 1L;
+
+        ReflectionTestUtils.setField(payment, "payStatus", PaymentStatus.PAID);
+
+        given(order.getUserId()).willReturn(userId);
         given(paymentRepository.findById(anyLong())).willReturn(Optional.of(payment));
 
-        AppException e = assertThrows(AppException.class, () -> paymentService.getPaymentDetails(1L));
+        AppException e = assertThrows(AppException.class, () -> paymentService.getPaymentDetails(userId, 1L));
         Assertions.assertEquals("INVALID_PAYMENT_STATUS", e.getErrorCode().toString());
     }
 
@@ -151,7 +160,7 @@ public class PaymentServiceTest {
         assertThat(payment.getPayStatus()).isEqualTo(PaymentStatus.CANCELLED);
         assertThat(payment.getCancelableAmount()).isEqualTo(0);
         verify(order).changeOrderStatus(OrderStatus.CANCELLED);
-        verify(publisher).publishEvent(any(PaymentApprovedEvent.class));
+        verify(publisher).publishEvent(any(PaymentStatusChangedEvent.class));
     }
 
     @Test


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
closed #66 

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
- 도메인에 종속되지 않도록 global.s3 패키지를 생성
- 동시 업로드 및 동일 파일명 충돌을 예방하기 위해 고유 문자열(UUID) 기반의 파일명 변환 로직 사용
- 독립적으로 기능을 검증할 수 있는 임시 엔드포인트(POST /api/v1/images/upload)를 GlobalImageController 구현

## 😅 Uncompleted Tasks
[//]: # (없다면 N/A)
- [ ] Task1

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
GlobalImageController 기존의 MEMBER 권한을 가지면 사용할 수 있도록 했습니다. 혹시 그냥 permitAll()로 하지 고민 되는데 의견 공유해주시면 감사하겠습니다.

타 도메인 서비스에서의 활용 방법 (DI)각자 담당하신 도메인 서비스(예: PostService)에서 global 패키지의 서비스를 주입받아 아주 간단하게 호출할 수 있습니다.
```
@Service
@RequiredArgsConstructor
public class PostService {
    // 1. global 패키지의 공통 서비스 주입
    private final S3UploadService s3UploadService; 

    public void createPost(PostCreateDto dto, MultipartFile image) {
        // 2. 메서드 호출 후 반환된 String 주소를 DB에 그대로 저장
        String imageUrl = s3UploadService.uploadImage(image, "product");  
       // 파일, 도메인 폴더 이름(각자가 원하는 폴더 이름 사용하셔도 될 듯 합니다.
       // ❗️도메인 별로 각자의 폴더에 이미지를 저장하도록 했습니다.❗️
        
        // 데이터베이스 Entity 세팅 로직...
    }

    public void deletePost(Long postId) {
        Post post = postRepository.findById(postId).orElseThrow();

        s3UploadService.deleteImage(post.getImageUrl());

        postRepository.delete(post);
}
```
