### PR TITLE
Feat: 상품 기본 정보 수정 및 상태 변경 API

### DIFF
--- a/src/main/java/com/example/i_commerce/domain/product/application/service/ProductUpdateService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/ProductUpdateService.java
@@ -1,6 +1,7 @@
 package com.example.i_commerce.domain.product.application.service;
 
 
+import com.example.i_commerce.domain.product.controller.request.UpdateProductRequest;
 import com.example.i_commerce.domain.product.controller.request.UpdateProductStatusRequest;
 import com.example.i_commerce.domain.product.controller.response.UpdateProductStatusResponse;
 import com.example.i_commerce.domain.product.entity.Product;
@@ -17,6 +18,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProductUpdateService {
 
     private final ProductRepository productRepository;
+
+    public void updateBasicInfo(
+        Long productId,
+        Long userId,
+        UpdateProductRequest request
+    ) {
+        Product product = productRepository.findById(productId)
+            .orElseThrow(() -> new AppException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        product.updateBasicInfo(request.name(),request.description());
+    }
 
     public UpdateProductStatusResponse changeProductStatus(
         Long productId,

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/ProductUpdateService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/ProductUpdateService.java
@@ -1,0 +1,34 @@
+package com.example.i_commerce.domain.product.application.service;
+
+
+import com.example.i_commerce.domain.product.controller.request.UpdateProductStatusRequest;
+import com.example.i_commerce.domain.product.controller.response.UpdateProductStatusResponse;
+import com.example.i_commerce.domain.product.entity.Product;
+import com.example.i_commerce.domain.product.exception.ProductErrorCode;
+import com.example.i_commerce.domain.product.repository.ProductRepository;
+import com.example.i_commerce.global.exception.AppException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProductUpdateService {
+
+    private final ProductRepository productRepository;
+
+    public UpdateProductStatusResponse changeProductStatus(
+        Long productId,
+        Long userId,
+        UpdateProductStatusRequest request
+    ) {
+        Product product = ( request.status().requiresItemCascade()
+            ? productRepository.findByIdWithItemsAndStock(productId)
+            : productRepository.findById(productId)
+        ).orElseThrow(() -> new AppException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        product.changeStatus(request.status());
+        return UpdateProductStatusResponse.from(product);
+    }
+}

--- a/src/main/java/com/example/i_commerce/domain/product/controller/ProductSellerController.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/ProductSellerController.java
@@ -4,6 +4,7 @@ package com.example.i_commerce.domain.product.controller;
 import com.example.i_commerce.domain.product.application.service.ProductService;
 import com.example.i_commerce.domain.product.application.service.ProductUpdateService;
 import com.example.i_commerce.domain.product.controller.request.CreateProductRequest;
+import com.example.i_commerce.domain.product.controller.request.UpdateProductRequest;
 import com.example.i_commerce.domain.product.controller.request.UpdateProductStatusRequest;
 import com.example.i_commerce.domain.product.controller.response.CreatedProductResponse;
 import com.example.i_commerce.domain.product.controller.response.UpdateProductStatusResponse;
@@ -36,10 +37,20 @@ public class ProductSellerController {
     @Operation(summary = "상품 생성", description = "상품을 생성한다.")
     @PostMapping
     public ApiResponse<CreatedProductResponse> createProduct(
-        Long sellerId,
+        @AuthenticationPrincipal CustomUserPrincipal principal,
         @RequestBody @Validated CreateProductRequest request
     ) {
-        return ApiResponse.success(productService.createProduct(sellerId, request));
+        return ApiResponse.success(productService.createProduct(principal.getId(), request));
+    }
+
+    @PatchMapping("/{productId}")
+    public ApiResponse<Void> updateProduct(
+        @PathVariable Long productId,
+        @AuthenticationPrincipal CustomUserPrincipal principal,
+        @Valid @RequestBody UpdateProductRequest request
+    ) {
+        productUpdateService.updateBasicInfo(productId, principal.getId(), request);
+        return ApiResponse.success();
     }
 
     @PatchMapping("/{productId}/status")

--- a/src/main/java/com/example/i_commerce/domain/product/controller/ProductSellerController.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/ProductSellerController.java
@@ -2,14 +2,22 @@ package com.example.i_commerce.domain.product.controller;
 
 
 import com.example.i_commerce.domain.product.application.service.ProductService;
+import com.example.i_commerce.domain.product.application.service.ProductUpdateService;
 import com.example.i_commerce.domain.product.controller.request.CreateProductRequest;
+import com.example.i_commerce.domain.product.controller.request.UpdateProductStatusRequest;
 import com.example.i_commerce.domain.product.controller.response.CreatedProductResponse;
+import com.example.i_commerce.domain.product.controller.response.UpdateProductStatusResponse;
 import com.example.i_commerce.global.common.response.ApiResponse;
+import com.example.i_commerce.global.security.principal.CustomUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,10 +27,11 @@ import org.springframework.web.bind.annotation.RestController;
 @SecurityRequirement(name = "BearerAuth")
 @RestController
 @AllArgsConstructor
-@RequestMapping("/api/v1/seller/products")
+@RequestMapping("/api/v1/products")
 public class ProductSellerController {
 
     private final ProductService productService;
+    private final ProductUpdateService productUpdateService;
 
     @Operation(summary = "상품 생성", description = "상품을 생성한다.")
     @PostMapping
@@ -31,6 +40,17 @@ public class ProductSellerController {
         @RequestBody @Validated CreateProductRequest request
     ) {
         return ApiResponse.success(productService.createProduct(sellerId, request));
+    }
+
+    @PatchMapping("/{productId}/status")
+    public ApiResponse<UpdateProductStatusResponse> changeStatus(
+        @PathVariable Long productId,
+        @AuthenticationPrincipal CustomUserPrincipal principal,
+        @Valid @RequestBody UpdateProductStatusRequest request
+    ) {
+        UpdateProductStatusResponse res =
+            productUpdateService.changeProductStatus(productId, principal.getId(), request);
+        return ApiResponse.success(res);
     }
 
 }

--- a/src/main/java/com/example/i_commerce/domain/product/controller/request/UpdateProductRequest.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/request/UpdateProductRequest.java
@@ -1,0 +1,17 @@
+package com.example.i_commerce.domain.product.controller.request;
+
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+
+public record UpdateProductRequest(
+    @NotBlank(message = "상품명은 필수입니다.")
+    @Size(max = 100, message = "상품명은 100자 이하여야 합니다.")
+    String name,
+
+    @Size(max = 1000, message = "상품 설명은 1000자 이하여야 합니다.")
+    String description
+) {
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/controller/request/UpdateProductStatusRequest.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/request/UpdateProductStatusRequest.java
@@ -1,0 +1,11 @@
+package com.example.i_commerce.domain.product.controller.request;
+
+import com.example.i_commerce.domain.product.entity.ProductStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateProductStatusRequest(
+    @NotNull(message = "변경할 상태는 필수입니다.")
+    ProductStatus status
+) {
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/controller/response/UpdateProductStatusResponse.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/response/UpdateProductStatusResponse.java
@@ -1,0 +1,18 @@
+package com.example.i_commerce.domain.product.controller.response;
+
+import com.example.i_commerce.domain.product.entity.Product;
+import com.example.i_commerce.domain.product.entity.ProductStatus;
+import lombok.Builder;
+
+@Builder
+public record UpdateProductStatusResponse(
+    Long productId,
+    ProductStatus status
+) {
+    public static UpdateProductStatusResponse from(Product product) {
+        return UpdateProductStatusResponse.builder()
+            .productId(product.getId())
+            .status(product.getStatus())
+            .build();
+    }
+}

--- a/src/main/java/com/example/i_commerce/domain/product/entity/Product.java
+++ b/src/main/java/com/example/i_commerce/domain/product/entity/Product.java
@@ -114,6 +114,11 @@ public class Product extends BaseEntity {
             .orElseThrow(() -> new AppException(ProductErrorCode.PRODUCT_ITEM_NOT_FOUND));
     }
 
+    public void updateBasicInfo(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
     public void changeStatus(ProductStatus newStatus) {
         if (this.status == newStatus) {
             return;

--- a/src/main/java/com/example/i_commerce/domain/product/entity/Product.java
+++ b/src/main/java/com/example/i_commerce/domain/product/entity/Product.java
@@ -114,4 +114,16 @@ public class Product extends BaseEntity {
             .orElseThrow(() -> new AppException(ProductErrorCode.PRODUCT_ITEM_NOT_FOUND));
     }
 
+    public void changeStatus(ProductStatus newStatus) {
+        if (this.status == newStatus) {
+            return;
+        }
+        this.status.validateTransition(newStatus);
+        this.status = newStatus;
+
+        if (newStatus == ProductStatus.DISCONTINUED) {
+            this.items.forEach(ProductItem::discontinue);
+        }
+    }
+
 }

--- a/src/main/java/com/example/i_commerce/domain/product/entity/ProductItem.java
+++ b/src/main/java/com/example/i_commerce/domain/product/entity/ProductItem.java
@@ -87,6 +87,7 @@ public class ProductItem extends BaseEntity {
             .displayOptionName(displayOptionName)
             .optionValue1(optionValue1)
             .optionValue2(optionValue2)
+            .status(ProductItemStatus.ON_SALE)
             .isDefault(isDefault)
             .build();
     }
@@ -105,6 +106,14 @@ public class ProductItem extends BaseEntity {
 
     public void changeStatus(ProductItemStatus status) {
         this.status = status;
+    }
+
+    void discontinue() {
+        if (this.status == ProductItemStatus.OFF_SALE) {
+            return;
+        }
+        this.status = ProductItemStatus.OFF_SALE;
+        this.stock.markUnavailable();
     }
 
     void setProduct(Product product) {

--- a/src/main/java/com/example/i_commerce/domain/product/entity/ProductItemStatus.java
+++ b/src/main/java/com/example/i_commerce/domain/product/entity/ProductItemStatus.java
@@ -1,6 +1,10 @@
 package com.example.i_commerce.domain.product.entity;
 
 
+import com.example.i_commerce.domain.product.exception.ProductErrorCode;
+import com.example.i_commerce.global.exception.AppException;
+import java.util.Map;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,10 +12,24 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ProductItemStatus {
     ON_SALE("판매중", "판매 중인 상품입니다."),
+    OFF_SALE("판매 중지", "판매 중지된 상품입니다."),
     OUT_OF_STOCK("재고 없음", "현재 재고가 없는 상품입니다."),
 
     ;
 
     private final String status;
     private final String description;
+
+    private static final Map<ProductItemStatus, Set<ProductItemStatus>> TRANSITIONS = Map.of(
+        ON_SALE,      Set.of(OFF_SALE, OUT_OF_STOCK),
+        OFF_SALE,     Set.of(ON_SALE),
+        OUT_OF_STOCK, Set.of(ON_SALE, OFF_SALE)
+    );
+
+    public void validateTransition(ProductItemStatus target) {
+        if (this == target) return;
+        if (!TRANSITIONS.get(this).contains(target)) {
+            throw new AppException(ProductErrorCode.INVALID_STATUS_TRANSITION);
+        }
+    }
 }

--- a/src/main/java/com/example/i_commerce/domain/product/entity/ProductStatus.java
+++ b/src/main/java/com/example/i_commerce/domain/product/entity/ProductStatus.java
@@ -1,6 +1,10 @@
 package com.example.i_commerce.domain.product.entity;
 
 
+import com.example.i_commerce.domain.product.exception.ProductErrorCode;
+import com.example.i_commerce.global.exception.AppException;
+import java.util.Map;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -14,4 +18,25 @@ public enum ProductStatus {
 
     private final String status;
     private final String description;
+
+    private static final Map<ProductStatus, Set<ProductStatus>> TRANSITIONS = Map.of(
+        PENDING,      Set.of(ON_SALE, DISCONTINUED),
+        ON_SALE,      Set.of(PENDING, DISCONTINUED),
+        DISCONTINUED, Set.of(PENDING)
+    );
+
+    public boolean requiresItemCascade() {
+        return this == DISCONTINUED;
+    }
+
+    public boolean canTransitionTo(ProductStatus target) {
+        return TRANSITIONS.get(this).contains(target);
+    }
+
+    public void validateTransition(ProductStatus target) {
+        if (this == target) return;
+        if (!canTransitionTo(target)) {
+            throw new AppException(ProductErrorCode.INVALID_STATUS_TRANSITION);
+        }
+    }
 }

--- a/src/main/java/com/example/i_commerce/domain/product/entity/Stock.java
+++ b/src/main/java/com/example/i_commerce/domain/product/entity/Stock.java
@@ -58,6 +58,7 @@ public class Stock extends BaseEntity {
         return Stock.builder()
             .productItem(item)
             .quantity(quantity)
+            .status(StockStatus.IN_STOCK)
             .build();
     }
 
@@ -84,10 +85,12 @@ public class Stock extends BaseEntity {
         return this.status == StockStatus.OUT_OF_STOCK;
     }
 
+    public void markUnavailable() {
+        if (this.status == StockStatus.UNAVAILABLE) {
+            return;
+        }
+        this.status = StockStatus.UNAVAILABLE;
+    }
+
 }
-
-
-
-
-
 

--- a/src/main/java/com/example/i_commerce/domain/product/entity/StockStatus.java
+++ b/src/main/java/com/example/i_commerce/domain/product/entity/StockStatus.java
@@ -6,7 +6,8 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public enum StockStatus {
     IN_STOCK("재고 있음"),
-    OUT_OF_STOCK("재고 없음")
+    OUT_OF_STOCK("재고 없음"),
+    UNAVAILABLE("사용할 수 없음")
     ;
 
     private final String description;

--- a/src/main/java/com/example/i_commerce/domain/product/exception/ProductErrorCode.java
+++ b/src/main/java/com/example/i_commerce/domain/product/exception/ProductErrorCode.java
@@ -32,8 +32,10 @@ public enum ProductErrorCode implements ErrorCode {
     GUEST_PAGE_LIMIT_EXCEEDED(HttpStatus.FORBIDDEN, "PRD-40301", "비로그인 사용자는 더 이상 페이지를 조회할 수 없습니다."),
 
     INVALID_OPTION_TYPE(HttpStatus.CONFLICT, "PRD-40905", "존재하지 않는 옵션 타입입니다."),
-    INSUFFICIENT_STOCK(HttpStatus.CONFLICT, "PRD-40903", "재고가 충분하지 않습니다.")
+    INSUFFICIENT_STOCK(HttpStatus.CONFLICT, "PRD-40903", "재고가 충분하지 않습니다."),
 
+
+    INVALID_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "PRD-40001", "허용되지 않는 상태 변경입니다."),
 
     ;
 

--- a/src/main/java/com/example/i_commerce/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/ProductRepository.java
@@ -1,10 +1,20 @@
 package com.example.i_commerce.domain.product.repository;
 
 import com.example.i_commerce.domain.product.entity.Product;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
+    @Query("""
+      SELECT p FROM Product p
+      LEFT JOIN FETCH p.items i
+      LEFT JOIN FETCH i.stock
+      WHERE p.id = :id
+    """)
+    Optional<Product> findByIdWithItemsAndStock(@Param("id") Long id);
 }


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
- closed #77 -> develop


## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
상품 기본 정보를 수정하는 api, 상태를 변경하는 api를 개발했습니다.
- 기본 정보인 상품 명, 상품 설명을 변경할 수 있습니다.
- 상태 전이 조건과 조건을 위반한 경우의 에러 코드를 추가했습니다.
- 상품 상태가 DISCONTINUED로 변경될 경우, 하위 아이템들의 상태도 변경됩니다.

## 😅 Uncompleted Tasks
[//]: # (없다면 N/A)
store 도메인에서 정보를 가져와 seller가 현재 로그인된 유저인지 확인하는 검증이 빠져있습니다. store 서비스 추가하시면 사용하겠습니다.
- [ ] seller 검증 추가

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
- 원래 나눠서 pr 올리려고 했는데 빠르게 진행하기 위해 합쳐서 올립니다.
- 기타 궁금하신 점, 개선 필요한 부분 의견 주세요~~