### PR TITLE
Feat: 카테고리 제공 속성 추가 및 조회 API 

### DIFF
--- a/src/main/java/com/example/i_commerce/domain/product/application/dto/CategoryAttributeGroupDto.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/dto/CategoryAttributeGroupDto.java
@@ -1,0 +1,44 @@
+package com.example.i_commerce.domain.product.application.dto;
+
+import com.example.i_commerce.domain.product.repository.projection.CategoryAttributeProjection;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record CategoryAttributeGroupDto(
+    String attributeKey,
+    List<CategoryAttributeValueDto> attributeValues
+
+) {
+
+    public static CategoryAttributeGroupDto of(
+        String attributeKey,
+        List<CategoryAttributeValueDto> attributeValues
+    ) {
+        return CategoryAttributeGroupDto.builder()
+            .attributeKey(attributeKey)
+            .attributeValues(attributeValues)
+            .build();
+    }
+
+    @Builder
+    public record CategoryAttributeValueDto(
+        Long categoryAttributeId,
+        Long attributeId,
+        String value,
+        Boolean required
+    ) {
+
+        public static CategoryAttributeValueDto from(
+            CategoryAttributeProjection projection
+        ) {
+            return CategoryAttributeValueDto.builder()
+                .categoryAttributeId(projection.categoryAttributeId())
+                .attributeId(projection.attributeId())
+                .value(projection.attributeValue())
+                .required(projection.required())
+                .build();
+        }
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/application/mapper/CategoryAttributeMapper.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/mapper/CategoryAttributeMapper.java
@@ -1,0 +1,40 @@
+package com.example.i_commerce.domain.product.application.mapper;
+
+import com.example.i_commerce.domain.product.application.dto.CategoryAttributeGroupDto;
+import com.example.i_commerce.domain.product.application.dto.CategoryAttributeGroupDto.CategoryAttributeValueDto;
+import com.example.i_commerce.domain.product.repository.projection.CategoryAttributeProjection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CategoryAttributeMapper {
+
+    public List<CategoryAttributeGroupDto> toGroupResponse(
+        List<CategoryAttributeProjection> projections
+    ) {
+        return projections.stream()
+            .collect(Collectors.groupingBy(
+                CategoryAttributeProjection::attributeKey,
+                LinkedHashMap::new,
+                Collectors.toList()
+            ))
+            .entrySet().stream()
+            .map(this::toGroupResponse)
+            .toList();
+    }
+
+    private CategoryAttributeGroupDto toGroupResponse(
+        Entry<String, List<CategoryAttributeProjection>> entry
+    ) {
+        return CategoryAttributeGroupDto.of(
+            entry.getKey(),
+            entry.getValue().stream()
+                .map(CategoryAttributeValueDto::from)
+                .toList()
+        );
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryAttributeService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryAttributeService.java
@@ -1,9 +1,12 @@
 package com.example.i_commerce.domain.product.application.service;
 
 
+import com.example.i_commerce.domain.product.application.mapper.CategoryAttributeMapper;
 import com.example.i_commerce.domain.product.controller.request.AddCategoryAttributeRequest;
 import com.example.i_commerce.domain.product.controller.response.AddCategoryAttributeResponse;
 import com.example.i_commerce.domain.product.controller.response.AddCategoryAttributeResponse.AlreadyExistsAttribute;
+import com.example.i_commerce.domain.product.application.dto.CategoryAttributeGroupDto;
+import com.example.i_commerce.domain.product.controller.response.CategoryAttributeResponse;
 import com.example.i_commerce.domain.product.entity.Attribute;
 import com.example.i_commerce.domain.product.entity.Category;
 import com.example.i_commerce.domain.product.entity.CategoryAttribute;
@@ -12,6 +15,7 @@ import com.example.i_commerce.domain.product.repository.AttributeRepository;
 import com.example.i_commerce.domain.product.repository.CategoryAttributeRepository;
 import com.example.i_commerce.domain.product.repository.CategoryRepository;
 import com.example.i_commerce.domain.product.repository.projection.CategoryAttributeKey;
+import com.example.i_commerce.domain.product.repository.projection.CategoryAttributeProjection;
 import com.example.i_commerce.global.exception.AppException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -30,6 +34,23 @@ public class CategoryAttributeService {
     private final CategoryRepository categoryRepository;
     private final AttributeRepository attributeRepository;
     private final CategoryAttributeRepository categoryAttributeRepository;
+    private final CategoryAttributeMapper categoryAttributeMapper;
+
+    @Transactional(readOnly = true)
+    public CategoryAttributeResponse getAttributesByCategory(Long categoryId) {
+
+        if(!categoryRepository.existsById(categoryId)) {
+            throw new AppException(ProductErrorCode.CATEGORY_NOT_FOUND);
+        }
+
+        List<CategoryAttributeProjection> projections =
+            categoryAttributeRepository.findWithAttributeByCategoryId(categoryId);
+
+        List<CategoryAttributeGroupDto> groupedCategoryAttributes =
+            categoryAttributeMapper.toGroupResponse(projections);
+
+        return CategoryAttributeResponse.of(categoryId, groupedCategoryAttributes);
+    }
 
     @Transactional
     public AddCategoryAttributeResponse addCategoryAttribute(

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryAttributeService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryAttributeService.java
@@ -64,18 +64,18 @@ public class CategoryAttributeService {
             throw new AppException(ProductErrorCode.ATTRIBUTE_NOT_FOUND);
         }
 
-        List<Long> tagetCategoryIds = (request.propagateToChildren())
+        List<Long> targetCategoryIds = (request.propagateToChildren())
             ? categoryRepository.findAllDescendantIds(categoryId)
             : List.of(categoryId);
 
         Set<CategoryAttributeKey> existingKeys = new HashSet<>(
-            categoryAttributeRepository.findExistingKeys(tagetCategoryIds, request.attributeIds())
+            categoryAttributeRepository.findExistingKeys(targetCategoryIds, request.attributeIds())
         );
 
         List<CategoryAttribute> categoryAttributes = new ArrayList<>();
         List<AlreadyExistsAttribute> existsAttributes = new ArrayList<>();
 
-        for(Long targetCategoryId : tagetCategoryIds) {
+        for(Long targetCategoryId : targetCategoryIds) {
             Category categoryRef = categoryRepository.getReferenceById(targetCategoryId);
             for(Attribute attribute : attributes) {
                 if(existingKeys.contains(new CategoryAttributeKey(targetCategoryId, attribute.getId()))) {

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryAttributeService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryAttributeService.java
@@ -20,9 +20,7 @@ import com.example.i_commerce.global.exception.AppException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,13 +75,8 @@ public class CategoryAttributeService {
         List<CategoryAttribute> categoryAttributes = new ArrayList<>();
         List<AlreadyExistsAttribute> existsAttributes = new ArrayList<>();
 
-        Map<Long, Category> categoryRefMap = tagetCategoryIds.stream()
-            .collect(Collectors.toMap(
-                id -> id,
-                categoryRepository::getReferenceById
-            ));
-
         for(Long targetCategoryId : tagetCategoryIds) {
+            Category categoryRef = categoryRepository.getReferenceById(targetCategoryId);
             for(Attribute attribute : attributes) {
                 if(existingKeys.contains(new CategoryAttributeKey(targetCategoryId, attribute.getId()))) {
                     existsAttributes.add(AlreadyExistsAttribute.of(
@@ -92,7 +85,7 @@ public class CategoryAttributeService {
                     continue;
                 }
                 categoryAttributes.add(CategoryAttribute.of(
-                    categoryRefMap.get(targetCategoryId),
+                    categoryRef,
                     attribute,
                     request.required()
                 ));

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryAttributeService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryAttributeService.java
@@ -1,0 +1,85 @@
+package com.example.i_commerce.domain.product.application.service;
+
+
+import com.example.i_commerce.domain.product.controller.request.AddCategoryAttributeRequest;
+import com.example.i_commerce.domain.product.controller.response.AddCategoryAttributeResponse;
+import com.example.i_commerce.domain.product.controller.response.AddCategoryAttributeResponse.AlreadyExistsAttribute;
+import com.example.i_commerce.domain.product.entity.Attribute;
+import com.example.i_commerce.domain.product.entity.Category;
+import com.example.i_commerce.domain.product.entity.CategoryAttribute;
+import com.example.i_commerce.domain.product.exception.ProductErrorCode;
+import com.example.i_commerce.domain.product.repository.AttributeRepository;
+import com.example.i_commerce.domain.product.repository.CategoryAttributeRepository;
+import com.example.i_commerce.domain.product.repository.CategoryRepository;
+import com.example.i_commerce.domain.product.repository.projection.CategoryAttributeKey;
+import com.example.i_commerce.global.exception.AppException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryAttributeService {
+
+    private final CategoryRepository categoryRepository;
+    private final AttributeRepository attributeRepository;
+    private final CategoryAttributeRepository categoryAttributeRepository;
+
+    @Transactional
+    public AddCategoryAttributeResponse addCategoryAttribute(
+        Long categoryId,
+        AddCategoryAttributeRequest request
+    ) {
+        if(!categoryRepository.existsById(categoryId)) {
+            throw new AppException(ProductErrorCode.CATEGORY_NOT_FOUND);
+        }
+
+        List<Attribute> attributes = attributeRepository.findAllById(request.attributeIds());
+        if(request.attributeIds().size() != attributes.size()) {
+            throw new AppException(ProductErrorCode.ATTRIBUTE_NOT_FOUND);
+        }
+
+        List<Long> tagetCategoryIds = (request.propagateToChildren())
+            ? categoryRepository.findAllDescendantIds(categoryId)
+            : List.of(categoryId);
+
+        Set<CategoryAttributeKey> existingKeys = new HashSet<>(
+            categoryAttributeRepository.findExistingKeys(tagetCategoryIds, request.attributeIds())
+        );
+
+        List<CategoryAttribute> categoryAttributes = new ArrayList<>();
+        List<AlreadyExistsAttribute> existsAttributes = new ArrayList<>();
+
+        Map<Long, Category> categoryRefMap = tagetCategoryIds.stream()
+            .collect(Collectors.toMap(
+                id -> id,
+                categoryRepository::getReferenceById
+            ));
+
+        for(Long targetCategoryId : tagetCategoryIds) {
+            for(Attribute attribute : attributes) {
+                if(existingKeys.contains(new CategoryAttributeKey(targetCategoryId, attribute.getId()))) {
+                    existsAttributes.add(AlreadyExistsAttribute.of(
+                        targetCategoryId, attribute.getId()
+                    ));
+                    continue;
+                }
+                categoryAttributes.add(CategoryAttribute.of(
+                    categoryRefMap.get(targetCategoryId),
+                    attribute,
+                    request.required()
+                ));
+            }
+        }
+        categoryAttributeRepository.saveAll(categoryAttributes);
+
+        return AddCategoryAttributeResponse.of(categoryId, existsAttributes);
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/controller/CategoryAttributeController.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/CategoryAttributeController.java
@@ -4,9 +4,11 @@ package com.example.i_commerce.domain.product.controller;
 import com.example.i_commerce.domain.product.application.service.CategoryAttributeService;
 import com.example.i_commerce.domain.product.controller.request.AddCategoryAttributeRequest;
 import com.example.i_commerce.domain.product.controller.response.AddCategoryAttributeResponse;
+import com.example.i_commerce.domain.product.controller.response.CategoryAttributeResponse;
 import com.example.i_commerce.global.common.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,7 +21,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class CategoryAttributeController {
 
     private final CategoryAttributeService categoryAttributeService;
-    
+
+    @GetMapping
+    public ApiResponse<CategoryAttributeResponse> getCategoryAttributes(
+        @PathVariable Long categoryId
+    ){
+        CategoryAttributeResponse res =
+            categoryAttributeService.getAttributesByCategory(categoryId);
+        return ApiResponse.success(res);
+    }
+
 
     @PostMapping
     public ApiResponse<AddCategoryAttributeResponse> addCategoryAttribute(

--- a/src/main/java/com/example/i_commerce/domain/product/controller/CategoryAttributeController.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/CategoryAttributeController.java
@@ -1,0 +1,34 @@
+package com.example.i_commerce.domain.product.controller;
+
+
+import com.example.i_commerce.domain.product.application.service.CategoryAttributeService;
+import com.example.i_commerce.domain.product.controller.request.AddCategoryAttributeRequest;
+import com.example.i_commerce.domain.product.controller.response.AddCategoryAttributeResponse;
+import com.example.i_commerce.global.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/categories/{categoryId}/attributes")
+public class CategoryAttributeController {
+
+    private final CategoryAttributeService categoryAttributeService;
+    
+
+    @PostMapping
+    public ApiResponse<AddCategoryAttributeResponse> addCategoryAttribute(
+        @PathVariable Long categoryId,
+        @Valid @RequestBody AddCategoryAttributeRequest request
+    ){
+        AddCategoryAttributeResponse res =
+            categoryAttributeService.addCategoryAttribute(categoryId, request);
+        return ApiResponse.success(res);
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/controller/request/AddCategoryAttributeRequest.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/request/AddCategoryAttributeRequest.java
@@ -1,0 +1,28 @@
+package com.example.i_commerce.domain.product.controller.request;
+
+
+import com.example.i_commerce.global.validation.annotations.NoDuplicates;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+
+@Schema(description = "카테고리가 제공할 속성 추가 요청")
+public record AddCategoryAttributeRequest(
+
+    @Schema(description = "추가할 속성 ID 목록", example = "[1, 2, 3]")
+    @NotEmpty(message = "속성 ID 목록은 비어있을 수 없습니다.")
+    @NoDuplicates(message = "속성 ID는 중복될 수 없습니다.")
+    List<@Positive Long> attributeIds,
+
+    @Schema(description = "하위 카테고리에도 추가할지 여부", example = "false")
+    @NotNull
+    Boolean propagateToChildren,
+
+    @Schema(description = "필수 속성 여부", example = "false")
+    @NotNull
+    Boolean required
+) {
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/controller/response/AddCategoryAttributeResponse.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/response/AddCategoryAttributeResponse.java
@@ -1,0 +1,33 @@
+package com.example.i_commerce.domain.product.controller.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record AddCategoryAttributeResponse(
+    Long categoryId,
+    List<AlreadyExistsAttribute> skippedAttributes
+) {
+    public static AddCategoryAttributeResponse of(
+        Long categoryId,
+        List<AlreadyExistsAttribute> alreadyExistsAttributes
+    ) {
+        return AddCategoryAttributeResponse.builder()
+            .categoryId(categoryId)
+            .skippedAttributes(alreadyExistsAttributes)
+            .build();
+    }
+
+    @Builder
+    public record AlreadyExistsAttribute(
+        Long categoryId,
+        Long attributeId
+    ) {
+        public static AlreadyExistsAttribute of(Long categoryId, Long attributeId) {
+            return AlreadyExistsAttribute.builder()
+                .categoryId(categoryId)
+                .attributeId(attributeId)
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/example/i_commerce/domain/product/controller/response/CategoryAttributeResponse.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/response/CategoryAttributeResponse.java
@@ -1,0 +1,21 @@
+package com.example.i_commerce.domain.product.controller.response;
+
+import com.example.i_commerce.domain.product.application.dto.CategoryAttributeGroupDto;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record CategoryAttributeResponse(
+    Long categoryId,
+    List<CategoryAttributeGroupDto> attributes
+) {
+    public static CategoryAttributeResponse of(
+        Long categoryId,
+        List<CategoryAttributeGroupDto> attributes
+    ) {
+        return CategoryAttributeResponse.builder()
+            .categoryId(categoryId)
+            .attributes(attributes)
+            .build();
+    }
+}

--- a/src/main/java/com/example/i_commerce/domain/product/entity/CategoryAttribute.java
+++ b/src/main/java/com/example/i_commerce/domain/product/entity/CategoryAttribute.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,7 +18,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "category_attributes")
+@Table(
+    name = "category_attributes",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uk_category_attribute",
+        columnNames = {"category_id", "attribute_id"}
+    )
+)
 @Getter
 @Builder
 @AllArgsConstructor
@@ -38,5 +45,17 @@ public class CategoryAttribute extends BaseEntity {
 
     @Builder.Default
     private Boolean required = false;
+
+    public static CategoryAttribute of(
+        Category category,
+        Attribute attribute,
+        Boolean required
+    ) {
+        return CategoryAttribute.builder()
+            .category(category)
+            .attribute(attribute)
+            .required(required)
+            .build();
+    }
 
 }

--- a/src/main/java/com/example/i_commerce/domain/product/repository/CategoryAttributeRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/CategoryAttributeRepository.java
@@ -3,6 +3,7 @@ package com.example.i_commerce.domain.product.repository;
 
 import com.example.i_commerce.domain.product.entity.CategoryAttribute;
 import com.example.i_commerce.domain.product.repository.projection.CategoryAttributeKey;
+import com.example.i_commerce.domain.product.repository.projection.CategoryAttributeProjection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,6 +12,19 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CategoryAttributeRepository extends JpaRepository<CategoryAttribute, Long> {
+
+    @Query("""
+    SELECT new com.example.i_commerce.domain.product.repository.projection.CategoryAttributeProjection(
+        ca.id, ca.required, a.id, a.key, a.value
+    )
+    FROM CategoryAttribute ca
+    JOIN ca.attribute a
+    WHERE ca.category.id = :categoryId
+    ORDER BY a.key, a.value
+    """)
+    List<CategoryAttributeProjection> findWithAttributeByCategoryId(
+        @Param("categoryId") Long categoryId
+    );
 
     @Query("""
     SELECT new com.example.i_commerce.domain.product.repository.projection.CategoryAttributeKey(

--- a/src/main/java/com/example/i_commerce/domain/product/repository/CategoryAttributeRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/CategoryAttributeRepository.java
@@ -2,6 +2,7 @@ package com.example.i_commerce.domain.product.repository;
 
 
 import com.example.i_commerce.domain.product.entity.CategoryAttribute;
+import com.example.i_commerce.domain.product.repository.projection.CategoryAttributeKey;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,10 +12,24 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CategoryAttributeRepository extends JpaRepository<CategoryAttribute, Long> {
 
+    @Query("""
+    SELECT new com.example.i_commerce.domain.product.repository.projection.CategoryAttributeKey(
+        ca.category.id,
+        ca.attribute.id
+    )
+    FROM CategoryAttribute ca
+    WHERE ca.category.id IN :categoryIds
+    AND ca.attribute.id IN :attributeIds
+    """)
+    List<CategoryAttributeKey> findExistingKeys(
+        @Param("categoryIds") List<Long> categoryIds,
+        @Param("attributeIds") List<Long> attributeIds
+    );
+
+
     @Query("SELECT ca FROM CategoryAttribute ca "
         + "JOIN FETCH ca.attribute "
         + "WHERE ca.category.id = :categoryId ")
     List<CategoryAttribute> findByCategoryIdWithAttribute(@Param("categoryId") Long categoryId);
-
 
 }

--- a/src/main/java/com/example/i_commerce/domain/product/repository/projection/CategoryAttributeKey.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/projection/CategoryAttributeKey.java
@@ -1,0 +1,8 @@
+package com.example.i_commerce.domain.product.repository.projection;
+
+
+public record CategoryAttributeKey(
+    Long categoryId,
+    Long attributeId
+) {
+}

--- a/src/main/java/com/example/i_commerce/domain/product/repository/projection/CategoryAttributeProjection.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/projection/CategoryAttributeProjection.java
@@ -1,0 +1,11 @@
+package com.example.i_commerce.domain.product.repository.projection;
+
+public record CategoryAttributeProjection(
+    Long categoryAttributeId,
+    Boolean required,
+    Long attributeId,
+    String attributeKey,
+    String attributeValue
+) {
+
+}


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
- closed #81 -> develop

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
다음 두가지 api를 개발했습니다.
- 카테고리가 제공할 속성을 추가하는 api
- 카테고리가 제공하는 속성을 추가하는 api

다음 상황에는 공통적으로 오류를 반환합니다.
- 카테고리 id와 일치하는 카테고리 없을 경우

속성 추가 api 관련
- 속성을 추가할 때, 이미 존재하더라도 오류를 반환하지 않고 스킵됩니다. 스킵된 정보는 저장되어 응답 객체에 포함됩니다.
- 하위 카테고리에도 추가할 여부도 요청에 포함됩니다.

속성 조회 api 관련
- 그룹화를 위한 dto와 mapper가 추가되었습니다.
- 조회된 속성 결과가 없는 경우 빈 List가 반환됩니다.

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)

- 기능 단위로 나눠서 개발할까 하다가 빠르게 진행하기 위해 한 브런치에서 같이 개발했습니다 
- 기타 궁금하신 점, 개선 필요한 부분 말씀해주세요!