### PR TITLE
Feat: 카테고리 제공 옵션 추가 API

### DIFF
--- a/src/main/java/com/example/i_commerce/domain/product/application/dto/AlreadyExistsOption.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/dto/AlreadyExistsOption.java
@@ -1,0 +1,18 @@
+package com.example.i_commerce.domain.product.application.dto;
+
+import lombok.Builder;
+
+@Builder
+public record AlreadyExistsOption(
+    Long categoryId,
+    Long optionId
+) {
+
+    public static AlreadyExistsOption of(Long categoryId, Long optionId) {
+        return AlreadyExistsOption.builder()
+            .categoryId(categoryId)
+            .optionId(optionId)
+            .build();
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryOptionService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryOptionService.java
@@ -1,15 +1,25 @@
 package com.example.i_commerce.domain.product.application.service;
 
 
+import com.example.i_commerce.domain.product.application.dto.AlreadyExistsOption;
 import com.example.i_commerce.domain.product.application.mapper.CategoryOptionMapper;
+import com.example.i_commerce.domain.product.controller.request.AddCategoryOptionRequest;
+import com.example.i_commerce.domain.product.controller.response.AddCategoryOptionResponse;
 import com.example.i_commerce.domain.product.controller.response.CategoryOptionGroupResponse;
 import com.example.i_commerce.domain.product.entity.Category;
+import com.example.i_commerce.domain.product.entity.CategoryOption;
+import com.example.i_commerce.domain.product.entity.Option;
 import com.example.i_commerce.domain.product.exception.ProductErrorCode;
 import com.example.i_commerce.domain.product.repository.CategoryOptionRepository;
 import com.example.i_commerce.domain.product.repository.CategoryRepository;
+import com.example.i_commerce.domain.product.repository.OptionRepository;
+import com.example.i_commerce.domain.product.repository.projection.CategoryOptionKey;
 import com.example.i_commerce.domain.product.repository.projection.CategoryOptionProjection;
 import com.example.i_commerce.global.exception.AppException;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,8 +29,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class CategoryOptionService {
 
     private final CategoryRepository categoryRepository;
+    private final OptionRepository optionRepository;
     private final CategoryOptionRepository categoryOptionRepository;
-
     private final CategoryOptionMapper categoryOptionMapper;
 
     @Transactional(readOnly = true)
@@ -34,6 +44,54 @@ public class CategoryOptionService {
             .findOptionsByCategoryId(categoryId);
 
         return categoryOptionMapper.toGroupedResponseList(projections);
+    }
+
+    @Transactional
+    public AddCategoryOptionResponse addCategoryOptions(
+        Long categoryId,
+        AddCategoryOptionRequest request
+    ) {
+
+        if(!categoryRepository.existsById(categoryId)) {
+            throw new AppException(ProductErrorCode.CATEGORY_NOT_FOUND);
+        }
+
+        List<Option> options = optionRepository.findAllById(request.optionIds());
+        if(request.optionIds().size() != options.size()) {
+            throw new AppException(ProductErrorCode.OPTION_NOT_FOUND);
+        }
+
+        List<Long> targetCategoryIds = (request.propagateToChildren())
+            ? categoryRepository.findAllDescendantIds(categoryId)
+            : List.of(categoryId);
+
+        Set<CategoryOptionKey> existingKey = new HashSet<>(
+            categoryOptionRepository.findExistingKeys(targetCategoryIds, request.optionIds())
+        );
+
+        List<CategoryOption> categoryOptions = new ArrayList<>();
+        List<AlreadyExistsOption> existsOptions = new ArrayList<>();
+
+        for(Long targetCategoryId : targetCategoryIds) {
+            Category categoryRef = categoryRepository.getReferenceById(targetCategoryId);
+            for(Option option : options) {
+                if(existingKey.contains(new CategoryOptionKey(targetCategoryId, option.getId()))) {
+                    existsOptions.add(AlreadyExistsOption.of(
+                        targetCategoryId, option.getId()
+                    ));
+                    continue;
+                }
+                categoryOptions.add(CategoryOption.of(
+                    categoryRef,
+                    option,
+                    request.required()
+                ));
+            }
+        }
+
+        categoryOptionRepository.saveAll(categoryOptions);
+
+        return AddCategoryOptionResponse.of(categoryId, existsOptions);
     }
 
 }

--- a/src/main/java/com/example/i_commerce/domain/product/controller/CategoryOptionController.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/CategoryOptionController.java
@@ -1,12 +1,17 @@
 package com.example.i_commerce.domain.product.controller;
 
 import com.example.i_commerce.domain.product.application.service.CategoryOptionService;
+import com.example.i_commerce.domain.product.controller.request.AddCategoryOptionRequest;
+import com.example.i_commerce.domain.product.controller.response.AddCategoryOptionResponse;
 import com.example.i_commerce.domain.product.controller.response.CategoryOptionGroupResponse;
 import com.example.i_commerce.global.common.response.ApiResponse;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,6 +27,16 @@ public class CategoryOptionController {
         @PathVariable Long categoryId
     ) {
         return ApiResponse.success(categoryOptionService.getOptionsByCategory(categoryId));
+    }
+
+    @PostMapping
+    public ApiResponse<AddCategoryOptionResponse> addCategoryOption(
+        @PathVariable Long categoryId,
+        @Valid @RequestBody AddCategoryOptionRequest request
+    ) {
+        AddCategoryOptionResponse res =
+            categoryOptionService.addCategoryOptions(categoryId, request);
+        return ApiResponse.success(res);
     }
 
 }

--- a/src/main/java/com/example/i_commerce/domain/product/controller/request/AddCategoryOptionRequest.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/request/AddCategoryOptionRequest.java
@@ -1,0 +1,20 @@
+package com.example.i_commerce.domain.product.controller.request;
+
+import com.example.i_commerce.global.validation.annotations.NoDuplicates;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record AddCategoryOptionRequest(
+    @NotEmpty
+    @NoDuplicates
+    List<Long> optionIds,
+
+    @NotNull
+    Boolean propagateToChildren,
+
+    @NotNull
+    Boolean required
+) {
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/controller/response/AddCategoryOptionResponse.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/response/AddCategoryOptionResponse.java
@@ -1,0 +1,23 @@
+package com.example.i_commerce.domain.product.controller.response;
+
+import com.example.i_commerce.domain.product.application.dto.AlreadyExistsOption;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record AddCategoryOptionResponse(
+    Long categoryId,
+    List<AlreadyExistsOption> skippedOptions
+) {
+
+    public static AddCategoryOptionResponse of(
+        Long categoryId,
+        List<AlreadyExistsOption> alreadyExistsOptions
+    ) {
+        return AddCategoryOptionResponse.builder()
+            .categoryId(categoryId)
+            .skippedOptions(alreadyExistsOptions)
+            .build();
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/domain/product/entity/CategoryOption.java
+++ b/src/main/java/com/example/i_commerce/domain/product/entity/CategoryOption.java
@@ -38,4 +38,15 @@ public class CategoryOption extends BaseEntity {
     @Builder.Default
     private Boolean required = false;
 
+    public static CategoryOption of(
+        Category category,
+        Option option,
+        Boolean required
+    ) {
+        return CategoryOption.builder()
+            .category(category)
+            .option(option)
+            .required(required)
+            .build();
+    }
 }

--- a/src/main/java/com/example/i_commerce/domain/product/repository/CategoryOptionRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/CategoryOptionRepository.java
@@ -1,6 +1,7 @@
 package com.example.i_commerce.domain.product.repository;
 
 import com.example.i_commerce.domain.product.entity.CategoryOption;
+import com.example.i_commerce.domain.product.repository.projection.CategoryOptionKey;
 import com.example.i_commerce.domain.product.repository.projection.CategoryOptionProjection;
 import java.util.List;
 import java.util.Optional;
@@ -30,5 +31,19 @@ public interface CategoryOptionRepository extends JpaRepository<CategoryOption, 
     """)
     List<CategoryOptionProjection> findOptionsByCategoryId(
         @Param("categoryId") Long categoryId
+    );
+
+    @Query("""
+    SELECT new com.example.i_commerce.domain.product.repository.projection.CategoryOptionKey(
+        co.category.id,
+        co.option.id
+    )
+    FROM CategoryOption co
+    WHERE co.category.id IN :categoryIds
+    AND co.option.id IN :optionIds
+    """)
+    List<CategoryOptionKey> findExistingKeys(
+        @Param("categoryIds") List<Long> categoryIds,
+        @Param("optionIds") List<Long> optionIds
     );
 }

--- a/src/main/java/com/example/i_commerce/domain/product/repository/projection/CategoryOptionKey.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/projection/CategoryOptionKey.java
@@ -1,0 +1,8 @@
+package com.example.i_commerce.domain.product.repository.projection;
+
+public record CategoryOptionKey(
+    Long categoryId,
+    Long optionId
+) {
+
+}


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
- closed #86 -> develop

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
카테고리가 제공할 옵션을 추가하는 api를 개발했습니다.
요청의 하위 카테고리에 전파 여부에 따라 하위 카테고리에도 함께 추가될 수 있습니다.

다음 상황에 오류를 반환합니다.
- 일치하는 카테고리가 없는 경우
- 요청 받은 옵션 중 하나라도 일치하는 옵션이 없는 경우 

저장시 이미 존재할 경우, 오류를 반환하지 않고 스킵되며 dto로 저장되어 응답에 포함됩니다.

## 😅 Uncompleted Tasks
[//]: # (없다면 N/A)
- [ ] 관리자 검증 필요 (현재 테스트 불가능해 생략됨)

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
- 궁금하신 점, 개선 필요한 부분 말씀해주세요!

