### PR TITLE
Feat: 장바구니 상품 제거 API

### DIFF
--- a/src/main/java/com/example/i_commerce/domain/cart/controller/CartController.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/controller/CartController.java
@@ -2,6 +2,7 @@ package com.example.i_commerce.domain.cart.controller;
 
 
 import com.example.i_commerce.domain.cart.controller.request.AddCartItemRequest;
+import com.example.i_commerce.domain.cart.controller.request.DeleteCartItemRequest;
 import com.example.i_commerce.domain.cart.controller.response.AddCartItemResponse;
 import com.example.i_commerce.domain.cart.controller.response.CartResponse;
 import com.example.i_commerce.domain.cart.service.CartQueryService;
@@ -11,6 +12,7 @@ import com.example.i_commerce.global.security.principal.CustomUserPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -44,5 +46,14 @@ public class CartController {
         return ApiResponse.success(response);
     }
 
+
+    @DeleteMapping("/items")
+    public ApiResponse<Void> deleteCartItems(
+        @AuthenticationPrincipal CustomUserPrincipal principal,
+        @RequestBody @Valid DeleteCartItemRequest request
+    ) {
+        cartService.deleteItems(principal.getId(), request);
+        return ApiResponse.success();
+    }
 
 }

--- a/src/main/java/com/example/i_commerce/domain/cart/controller/CartController.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/controller/CartController.java
@@ -9,6 +9,8 @@ import com.example.i_commerce.domain.cart.service.CartQueryService;
 import com.example.i_commerce.domain.cart.service.CartService;
 import com.example.i_commerce.global.common.response.ApiResponse;
 import com.example.i_commerce.global.security.principal.CustomUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,6 +21,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+
+@Tag(name = "Cart API", description = "장바구니 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/carts")
@@ -27,7 +31,7 @@ public class CartController {
     private final CartService cartService;
     private final CartQueryService cartQueryService;
 
-
+    @Operation(summary = "상품 추가", description = "장바구니에 특정 상품을 추가합니다.")
     @PostMapping("/items")
     public ApiResponse<AddCartItemResponse> addCartItem(
         @AuthenticationPrincipal CustomUserPrincipal principal,
@@ -38,6 +42,7 @@ public class CartController {
     }
 
 
+    @Operation(summary = "장바구니 조회", description = "장바구니를 조회합니다.")
     @GetMapping
     public ApiResponse<CartResponse> getCart(
         @AuthenticationPrincipal CustomUserPrincipal principal
@@ -46,7 +51,7 @@ public class CartController {
         return ApiResponse.success(response);
     }
 
-
+    @Operation(summary = "상품 제거", description = "장바구니에서 특정 상품들을 제거합니다.")
     @DeleteMapping("/items")
     public ApiResponse<Void> deleteCartItems(
         @AuthenticationPrincipal CustomUserPrincipal principal,

--- a/src/main/java/com/example/i_commerce/domain/cart/controller/request/DeleteCartItemRequest.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/controller/request/DeleteCartItemRequest.java
@@ -1,0 +1,15 @@
+package com.example.i_commerce.domain.cart.controller.request;
+
+
+import com.example.i_commerce.global.validation.annotations.NoDuplicates;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record DeleteCartItemRequest(
+    @NotEmpty
+    @NoDuplicates(message = "중복된 상품이 있습니다.")
+    List<@NotNull Long> cartItemIds
+) {
+
+}

--- a/src/main/java/com/example/i_commerce/domain/cart/entity/Cart.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/entity/Cart.java
@@ -1,6 +1,8 @@
 package com.example.i_commerce.domain.cart.entity;
 
+import com.example.i_commerce.domain.cart.exception.CartErrorCode;
 import com.example.i_commerce.global.common.entity.BaseEntity;
+import com.example.i_commerce.global.exception.AppException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -10,9 +12,11 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -39,7 +43,7 @@ public class Cart extends BaseEntity {
     private Long userId;
 
     @Builder.Default
-    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL)
     private List<CartItem> cartItems = new ArrayList<>();
 
     public static Cart create(Long userId) {
@@ -58,4 +62,18 @@ public class Cart extends BaseEntity {
         this.cartItems.add(item);
     }
 
+    public void removeItems(List<Long> cartItemIds) {
+        Set<Long> requestedIds = new HashSet<>(cartItemIds);
+
+        List<CartItem> activeItemList = cartItems.stream()
+            .filter(item -> !item.isDeleted())
+            .filter(item -> requestedIds.contains(item.getId()))
+            .toList();
+
+        if(activeItemList.size() != cartItemIds.size()) {
+            throw new AppException(CartErrorCode.CART_ITEM_NOT_FOUND);
+        }
+
+        activeItemList.forEach(CartItem::delete);
+    }
 }

--- a/src/main/java/com/example/i_commerce/domain/cart/exception/CartErrorCode.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/exception/CartErrorCode.java
@@ -9,6 +9,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CartErrorCode implements ErrorCode {
 
+    CART_NOT_FOUND(HttpStatus.NOT_FOUND, "CRT-40401", "장바구니가 존재하지 않습니다."),
+    CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "CRT-40402", "장바구니에 상품이 존재하지 않습니다."),
+
     EXCEED_STOCK_QUANTITY(HttpStatus.CONFLICT, "CRT-40901", "재고를 초과했습니다."),
     PRODUCT_NOT_AVAILABLE(HttpStatus.CONFLICT, "CRT-40902", "사용할 수 없는 상품입니다."),
 

--- a/src/main/java/com/example/i_commerce/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/repository/CartItemRepository.java
@@ -14,6 +14,7 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
         SELECT ci
         FROM CartItem ci
         WHERE ci.cart.id = :cartId
+        AND ci.deletedAt IS NULL
         ORDER BY ci.createdAt DESC
     """)
     List<CartItem> findAllByCartId(@Param("cartId") Long cartId);

--- a/src/main/java/com/example/i_commerce/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/repository/CartRepository.java
@@ -14,8 +14,9 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
     @Query("""
         SELECT c
         FROM Cart c
-        LEFT JOIN FETCH c.cartItems
+        LEFT JOIN FETCH c.cartItems ci
         WHERE c.userId = :userId
+        AND ci.deletedAt IS NULL
     """)
     Optional<Cart> findByUserIdWithItems(Long userId);
 }

--- a/src/main/java/com/example/i_commerce/domain/cart/service/CartService.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/service/CartService.java
@@ -2,6 +2,7 @@ package com.example.i_commerce.domain.cart.service;
 
 
 import com.example.i_commerce.domain.cart.controller.request.AddCartItemRequest;
+import com.example.i_commerce.domain.cart.controller.request.DeleteCartItemRequest;
 import com.example.i_commerce.domain.cart.controller.response.AddCartItemResponse;
 import com.example.i_commerce.domain.cart.entity.Cart;
 import com.example.i_commerce.domain.cart.entity.CartItem;
@@ -56,6 +57,13 @@ public class CartService {
             });
 
         return AddCartItemResponse.from(cartItem);
+    }
+
+    public void deleteItems(Long userId, DeleteCartItemRequest request) {
+        Cart cart = cartRepository.findByUserIdWithItems(userId)
+            .orElseThrow(() -> new AppException(CartErrorCode.CART_NOT_FOUND));
+
+        cart.removeItems(request.cartItemIds());
     }
 
 }

--- a/src/main/java/com/example/i_commerce/global/swagger/SwaggerConfig.java
+++ b/src/main/java/com/example/i_commerce/global/swagger/SwaggerConfig.java
@@ -80,6 +80,17 @@ public class SwaggerConfig {
     }
 
     @Bean
+    public GroupedOpenApi cartApi() {
+        return GroupedOpenApi.builder()
+            .group("Cart")
+            .pathsToMatch(
+                "/api/v1/carts/**"
+            )
+            .addOpenApiCustomizer(securityCustomizer())
+            .build();
+    }
+
+    @Bean
     public GroupedOpenApi reviewApi() {
         return GroupedOpenApi.builder()
             .group("Review")


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
- closed #91 


## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
장바구니에서 선택한 상품을 제거하는 api를 개발했습니다.
- 로그인한 유저의 장바구니를 먼저 조회하고 없다면 오류를 반환합니다.
- 해당 장바구니에 속하지 않은 아이템 id가 요청된 경우 오류를 반환합니다.

기타 추가된 작업
- 기존 장바구니 조회 쿼리에서 삭제된 아이템은 보이지 않도록 수정했습니다.

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
- 궁금하신 점, 개선 필요한 부분 있으시면 편하게 주세요~!
