### PR TITLE
Fix: 옵션 있는 상품 생성시의 오류 수정

### DIFF
--- a/src/main/java/com/example/i_commerce/domain/product/application/validator/ProductOptionValidator.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/validator/ProductOptionValidator.java
@@ -32,7 +32,7 @@ public class ProductOptionValidator {
         List<OptionRequest> requests = request.options();
 
         Set<Long> availableOptions = categoryOptionRepository
-            .findByCategoryId(request.categoryId())
+            .findAllByCategoryId(request.categoryId())
             .stream()
             .map(CategoryOption::getOption)
             .map(Option::getId)

--- a/src/main/java/com/example/i_commerce/domain/product/repository/CategoryOptionRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/CategoryOptionRepository.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CategoryOptionRepository extends JpaRepository<CategoryOption, Long> {
 
-    Optional<CategoryOption> findByCategoryId(Long categoryId);
+    List<CategoryOption> findAllByCategoryId(Long categoryId);
 
     @Query("""
     SELECT


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
- closed #96 


## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
상품이 생성할 때 옵션을 지정하면 쿼리 오류가 나던 부분을 해결했습니다.
여러 값을 가져와야 하는 부분이 단건을 반환하도록 되어 있었어서 오류가 발생했었고, List를 return하도록 수정해서 해결했습니다.

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
- 너무 짧지만.. 궁금하신 점 있으시면 말씀해주세요~
