### PR TITLE
Fix: 장바구니 버그 수정

### DIFF
--- a/src/main/java/com/example/i_commerce/domain/cart/entity/Cart.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/entity/Cart.java
@@ -55,6 +55,7 @@ public class Cart extends BaseEntity {
     public Optional<CartItem> findCartItem(Long productId) {
         return cartItems.stream()
             .filter(item -> Objects.equals(item.getProductItemId(), productId))
+            .filter(item -> !item.isDeleted())
             .findFirst();
     }
 

--- a/src/main/java/com/example/i_commerce/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/repository/CartRepository.java
@@ -16,7 +16,6 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
         FROM Cart c
         LEFT JOIN FETCH c.cartItems ci
         WHERE c.userId = :userId
-        AND ci.deletedAt IS NULL
     """)
     Optional<Cart> findByUserIdWithItems(Long userId);
 }

--- a/src/main/java/com/example/i_commerce/domain/cart/service/CartService.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/service/CartService.java
@@ -33,7 +33,7 @@ public class CartService {
             throw new AppException(CartErrorCode.PRODUCT_NOT_AVAILABLE);
         }
 
-        Cart cart = cartRepository.findByUserIdWithItems(userId)
+        Cart cart = cartRepository.findByUserId(userId)
             .orElseGet(() -> cartRepository.save(Cart.create(userId)));
 
         CartItem cartItem = cart.findCartItem(request.productItemId())

--- a/src/main/java/com/example/i_commerce/domain/cart/service/CartService.java
+++ b/src/main/java/com/example/i_commerce/domain/cart/service/CartService.java
@@ -33,7 +33,7 @@ public class CartService {
             throw new AppException(CartErrorCode.PRODUCT_NOT_AVAILABLE);
         }
 
-        Cart cart = cartRepository.findByUserId(userId)
+        Cart cart = cartRepository.findByUserIdWithItems(userId)
             .orElseGet(() -> cartRepository.save(Cart.create(userId)));
 
         CartItem cartItem = cart.findCartItem(request.productItemId())


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
- closed #115 -> develop

장바구니 시연영상 촬영하면서 마주친 버그를 수정했습니다.


## ✏️ Work Description
[//]: # (작업 내용 간단 소개)

처음 생성된 후, 아이템 삭제하고 다시 아이템 넣으면 다시 생성되려는 문제
- 연결된 쿼리 메서드 변경

삭제된 아이템도 보이는 문제
- 아이템 조회 시 isDeleted 아닌 아이템만 조회되도록 변경


## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
- 궁금하신 점, 개선할 점 편하게 주세요~