### PR TITLE
Feat: 상품 도메인 삭제 API

### DIFF
--- a/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryAttributeService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryAttributeService.java
@@ -96,4 +96,19 @@ public class CategoryAttributeService {
         return AddCategoryAttributeResponse.of(categoryId, existsAttributes);
     }
 
+
+    @Transactional
+    public void deleteCategoryAttribute(Long categoryId, Long categoryAttributeId) {
+
+        if(!categoryRepository.existsById(categoryId)) {
+            throw new AppException(ProductErrorCode.CATEGORY_NOT_FOUND);
+        }
+
+        CategoryAttribute categoryAttribute = categoryAttributeRepository
+            .findByIdAndCategoryId(categoryAttributeId, categoryId)
+            .orElseThrow(() -> new AppException(ProductErrorCode.CATEGORY_ATTRIBUTE_NOT_FOUND));
+
+        categoryAttributeRepository.delete(categoryAttribute);
+    }
+
 }

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryAttributeService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryAttributeService.java
@@ -100,10 +100,6 @@ public class CategoryAttributeService {
     @Transactional
     public void deleteCategoryAttribute(Long categoryId, Long categoryAttributeId) {
 
-        if(!categoryRepository.existsById(categoryId)) {
-            throw new AppException(ProductErrorCode.CATEGORY_NOT_FOUND);
-        }
-
         CategoryAttribute categoryAttribute = categoryAttributeRepository
             .findByIdAndCategoryId(categoryAttributeId, categoryId)
             .orElseThrow(() -> new AppException(ProductErrorCode.CATEGORY_ATTRIBUTE_NOT_FOUND));

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryOptionService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryOptionService.java
@@ -102,10 +102,6 @@ public class CategoryOptionService {
     @Transactional
     public void deleteOption(Long categoryId, Long categoryOptionId) {
 
-        if(!categoryRepository.existsById(categoryId)) {
-            throw new AppException(ProductErrorCode.CATEGORY_NOT_FOUND);
-        }
-
         CategoryOption categoryOption = categoryOptionRepository
             .findByIdAndCategoryId(categoryOptionId, categoryId)
             .orElseThrow(() -> new AppException(ProductErrorCode.CATEGORY_OPTION_NOT_FOUND));

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryOptionService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryOptionService.java
@@ -32,6 +32,7 @@ public class CategoryOptionService {
     private final OptionRepository optionRepository;
     private final CategoryOptionRepository categoryOptionRepository;
 
+
     @Transactional(readOnly = true)
     public CategoryOptionResponse getOptionsByCategory(Long categoryId) {
 
@@ -96,5 +97,24 @@ public class CategoryOptionService {
 
         return AddCategoryOptionResponse.of(categoryId, existsOptions);
     }
+
+
+    @Transactional
+    public void deleteOption(Long categoryId, Long categoryOptionId) {
+
+        if(!categoryRepository.existsById(categoryId)) {
+            throw new AppException(ProductErrorCode.CATEGORY_NOT_FOUND);
+        }
+
+        CategoryOption categoryOption = categoryOptionRepository
+            .findByIdAndCategoryId(categoryOptionId, categoryId)
+            .orElseThrow(() ->
+                new AppException(ProductErrorCode.CATEGORY_OPTION_NOT_FOUND_HISTORY_NOT_FOUND)
+            );
+
+        categoryOptionRepository.delete(categoryOption);
+    }
+
+
 
 }

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryOptionService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryOptionService.java
@@ -108,9 +108,7 @@ public class CategoryOptionService {
 
         CategoryOption categoryOption = categoryOptionRepository
             .findByIdAndCategoryId(categoryOptionId, categoryId)
-            .orElseThrow(() ->
-                new AppException(ProductErrorCode.CATEGORY_OPTION_NOT_FOUND_HISTORY_NOT_FOUND)
-            );
+            .orElseThrow(() -> new AppException(ProductErrorCode.CATEGORY_OPTION_NOT_FOUND));
 
         categoryOptionRepository.delete(categoryOption);
     }

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryService.java
@@ -83,7 +83,7 @@ public class CategoryService {
 
         List<Long> categoryIds = categoryRepository.findAllDescendantIds(categoryId);
 
-        if(productRepository.existsActiveByCategoryIds(categoryIds)) {
+        if(productRepository.existsByCategoryIds(categoryIds)) {
             throw new AppException(ProductErrorCode.CATEGORY_HAS_PRODUCTS);
         }
 

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/CategoryService.java
@@ -6,6 +6,7 @@ import com.example.i_commerce.domain.product.controller.request.CreateCategoryRe
 import com.example.i_commerce.domain.product.controller.response.CreateCategoryResponse;
 import com.example.i_commerce.domain.product.entity.Category;
 import com.example.i_commerce.domain.product.exception.ProductErrorCode;
+import com.example.i_commerce.domain.product.repository.ProductRepository;
 import com.example.i_commerce.domain.product.repository.projection.CategoryTreeRow;
 import com.example.i_commerce.domain.product.controller.response.CategoryResponse;
 import com.example.i_commerce.domain.product.repository.CategoryRepository;
@@ -24,6 +25,7 @@ public class CategoryService {
     private static final int RECURSIVE_DEPTH_LIMIT = 5;
 
     private final CategoryRepository categoryRepository;
+    private final ProductRepository productRepository;
     private final CategoryMapper categoryMapper;
 
     @Transactional(readOnly = true)
@@ -71,6 +73,21 @@ public class CategoryService {
             : Category.createChild(parent, request.name(), MAX_DEPTH);
 
         return CreateCategoryResponse.from(categoryRepository.save(category));
+    }
+
+    @Transactional
+    public void deleteCategory(Long categoryId) {
+
+        categoryRepository.findById(categoryId)
+            .orElseThrow(() -> new AppException(ProductErrorCode.CATEGORY_NOT_FOUND));
+
+        List<Long> categoryIds = categoryRepository.findAllDescendantIds(categoryId);
+
+        if(productRepository.existsActiveByCategoryIds(categoryIds)) {
+            throw new AppException(ProductErrorCode.CATEGORY_HAS_PRODUCTS);
+        }
+
+        categoryRepository.deleteAllByIdInBatch(categoryIds);
     }
 
 

--- a/src/main/java/com/example/i_commerce/domain/product/application/service/OptionService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/OptionService.java
@@ -37,5 +37,13 @@ public class OptionService {
 
     }
 
+    @Transactional
+    public void deleteOption(Long optionId) {
+        Option option = optionRepository.findById(optionId)
+            .orElseThrow(() -> new AppException(ProductErrorCode.OPTION_NOT_FOUND));
+
+        optionRepository.delete(option);
+    }
+
 }
 

--- a/src/main/java/com/example/i_commerce/domain/product/controller/CategoryAttributeController.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/CategoryAttributeController.java
@@ -10,6 +10,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -37,6 +39,7 @@ public class CategoryAttributeController {
     }
 
     @Operation(summary = "카테고리 제공 속성 추가", description = "특정 카테고리에서 제공할 속성을 추가합니다.")
+    @PreAuthorize("@authChecker.canManageCategory()")
     @PostMapping
     public ApiResponse<AddCategoryAttributeResponse> addCategoryAttribute(
         @PathVariable Long categoryId,
@@ -45,6 +48,18 @@ public class CategoryAttributeController {
         AddCategoryAttributeResponse res =
             categoryAttributeService.addCategoryAttribute(categoryId, request);
         return ApiResponse.success(res);
+    }
+
+
+    @Operation(summary = "카테고리 제공 속성 제거", description = "특정 카테고리에서 제공할 속성을 제거합니다.")
+    @PreAuthorize("@authChecker.canManageCategory()")
+    @DeleteMapping("/{categoryAttributeId}")
+    public ApiResponse<Void> deleteCategoryAttribute(
+        @PathVariable Long categoryId,
+        @PathVariable Long categoryAttributeId
+    ) {
+        categoryAttributeService.deleteCategoryAttribute(categoryId, categoryAttributeId);
+        return ApiResponse.success();
     }
 
 }

--- a/src/main/java/com/example/i_commerce/domain/product/controller/CategoryController.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/CategoryController.java
@@ -11,6 +11,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -51,5 +53,14 @@ public class CategoryController {
     ) {
         return ApiResponse.success(categoryService.getCategoryById(categoryId));
     }
+
+    @Operation(summary = "특정 카테고리 삭제", description = "특정 카테고리를 삭제합니다.")
+    @PreAuthorize("@authChecker.canManageCategory()")
+    @DeleteMapping("/{categoryId}")
+    public ApiResponse<Void> deleteCategory(@PathVariable Long categoryId) {
+        categoryService.deleteCategory(categoryId);
+        return ApiResponse.success();
+    }
+
 
 }

--- a/src/main/java/com/example/i_commerce/domain/product/controller/CategoryController.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/CategoryController.java
@@ -31,11 +31,13 @@ public class CategoryController {
     private final CategoryService categoryService;
 
     @Operation(summary = "카테고리 생성", description = "제공할 카테고리를 생성합니다.")
+    @PreAuthorize("@authChecker.canManageCategory()")
     @PostMapping
     public ApiResponse<CreateCategoryResponse> createCategory(
         @Valid @RequestBody CreateCategoryRequest request
     ) {
-        return ApiResponse.success(categoryService.createCategory(request));
+        CreateCategoryResponse res = categoryService.createCategory(request);
+        return ApiResponse.success(res);
     }
 
     @Operation(summary = "전체 카테고리 조회", description = "존재하는 모든 카테고리를 조회합니다.")
@@ -43,15 +45,15 @@ public class CategoryController {
     public ApiResponse<List<CategoryResponse>> getAllCategories(
         @RequestParam(required = false) Integer maxDepth
     ) {
-        return ApiResponse.success(categoryService.getAllCategories(maxDepth));
+        List<CategoryResponse> res = categoryService.getAllCategories(maxDepth);
+        return ApiResponse.success(res);
     }
 
     @Operation(summary = "특정 카테고리 조회", description = "특정 카테고리를 조회합니다.")
     @GetMapping("/{categoryId}")
-    public ApiResponse<CategoryResponse> getCategories(
-        @PathVariable Long categoryId
-    ) {
-        return ApiResponse.success(categoryService.getCategoryById(categoryId));
+    public ApiResponse<CategoryResponse> getCategories(@PathVariable Long categoryId) {
+        CategoryResponse res = categoryService.getCategoryById(categoryId);
+        return ApiResponse.success(res);
     }
 
     @Operation(summary = "특정 카테고리 삭제", description = "특정 카테고리를 삭제합니다.")

--- a/src/main/java/com/example/i_commerce/domain/product/controller/CategoryOptionController.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/CategoryOptionController.java
@@ -9,6 +9,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -33,6 +35,7 @@ public class CategoryOptionController {
     }
 
     @Operation(summary = "카테고리 제공 옵션 추가", description = "특정 카테고리에서 제공할 옵션을 추가합니다.")
+    @PreAuthorize("@authChecker.canManageCategory()")
     @PostMapping
     public ApiResponse<AddCategoryOptionResponse> addCategoryOption(
         @PathVariable Long categoryId,
@@ -41,6 +44,17 @@ public class CategoryOptionController {
         AddCategoryOptionResponse res =
             categoryOptionService.addCategoryOptions(categoryId, request);
         return ApiResponse.success(res);
+    }
+
+    @Operation(summary = "카테고리 제공 옵션 제거", description = "특정 카테고리에서 제공할 옵션을 제거합니다.")
+    @PreAuthorize("@authChecker.canManageCategory()")
+    @DeleteMapping("/{categoryOptionId}")
+    public ApiResponse<Void> deleteCategoryOption(
+        @PathVariable Long categoryId,
+        @PathVariable Long categoryOptionId
+    ) {
+        categoryOptionService.deleteOption(categoryId, categoryOptionId);
+        return ApiResponse.success();
     }
 
 }

--- a/src/main/java/com/example/i_commerce/domain/product/controller/OptionController.java
+++ b/src/main/java/com/example/i_commerce/domain/product/controller/OptionController.java
@@ -10,7 +10,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Option API", description = "옵션 API")
 @RestController
 @RequiredArgsConstructor
+@PreAuthorize("@authChecker.canManageOption()")
 @RequestMapping("/api/v1/options")
 public class OptionController {
 
@@ -37,6 +41,13 @@ public class OptionController {
     @GetMapping
     public ApiResponse<List<OptionResponse>> getAllOptions() {
         return ApiResponse.success(optionService.getAllOptions());
+    }
+
+    @Operation(summary = "옵션 삭제", description = "옵션을 삭제합니다.")
+    @DeleteMapping("/{optionId}")
+    public ApiResponse<Void> deleteOption(@PathVariable Long optionId) {
+        optionService.deleteOption(optionId);
+        return ApiResponse.success();
     }
 
 }

--- a/src/main/java/com/example/i_commerce/domain/product/exception/ProductErrorCode.java
+++ b/src/main/java/com/example/i_commerce/domain/product/exception/ProductErrorCode.java
@@ -31,6 +31,9 @@ public enum ProductErrorCode implements ErrorCode {
     ATTRIBUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "PRD-40406","속성이 존재하지 않습니다."),
     STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "PRD-40407", "상품 재고가 존재하지 않습니다."),
     STOCK_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "PRD-40408", "재고 기록이 존재하지 않습니다."),
+    CATEGORY_OPTION_NOT_FOUND_HISTORY_NOT_FOUND(
+        HttpStatus.NOT_FOUND, "PRD-40409", "해당 카테고리의 옵션을 찾을 수 없습니다."
+    ),
 
 
     // 409 Conflict

--- a/src/main/java/com/example/i_commerce/domain/product/exception/ProductErrorCode.java
+++ b/src/main/java/com/example/i_commerce/domain/product/exception/ProductErrorCode.java
@@ -32,6 +32,7 @@ public enum ProductErrorCode implements ErrorCode {
     STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "PRD-40407", "상품 재고가 존재하지 않습니다."),
     STOCK_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "PRD-40408", "재고 기록이 존재하지 않습니다."),
     CATEGORY_OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "PRD-40409", "해당 카테고리의 옵션을 찾을 수 없습니다."),
+    CATEGORY_ATTRIBUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "PRD-40410", "해당 카테고리의 속성을 찾을 수 없습니다."),
 
 
     // 409 Conflict

--- a/src/main/java/com/example/i_commerce/domain/product/exception/ProductErrorCode.java
+++ b/src/main/java/com/example/i_commerce/domain/product/exception/ProductErrorCode.java
@@ -42,7 +42,7 @@ public enum ProductErrorCode implements ErrorCode {
     DUPLICATE_CATEGORY_NAME(HttpStatus.CONFLICT, "PRD-40904", "이미 존재하는 카테고리입니다."),
     STOCK_ALREADY_INITIALIZED(HttpStatus.CONFLICT, "PRD-40905", "재고가 이미 초기화되었습니다."),
     INSUFFICIENT_STOCK(HttpStatus.CONFLICT, "PRD-40906", "재고가 충분하지 않습니다."),
-
+    CATEGORY_HAS_PRODUCTS(HttpStatus.CONFLICT, "PRD-40907", "하위 상품이 존재하는 카테고리는 삭제할 수 없습니다."),
 
     ;
 

--- a/src/main/java/com/example/i_commerce/domain/product/exception/ProductErrorCode.java
+++ b/src/main/java/com/example/i_commerce/domain/product/exception/ProductErrorCode.java
@@ -31,9 +31,7 @@ public enum ProductErrorCode implements ErrorCode {
     ATTRIBUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "PRD-40406","속성이 존재하지 않습니다."),
     STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "PRD-40407", "상품 재고가 존재하지 않습니다."),
     STOCK_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "PRD-40408", "재고 기록이 존재하지 않습니다."),
-    CATEGORY_OPTION_NOT_FOUND_HISTORY_NOT_FOUND(
-        HttpStatus.NOT_FOUND, "PRD-40409", "해당 카테고리의 옵션을 찾을 수 없습니다."
-    ),
+    CATEGORY_OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "PRD-40409", "해당 카테고리의 옵션을 찾을 수 없습니다."),
 
 
     // 409 Conflict

--- a/src/main/java/com/example/i_commerce/domain/product/repository/CategoryAttributeRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/CategoryAttributeRepository.java
@@ -5,6 +5,7 @@ import com.example.i_commerce.domain.product.entity.CategoryAttribute;
 import com.example.i_commerce.domain.product.repository.projection.CategoryAttributeKey;
 import com.example.i_commerce.domain.product.repository.projection.CategoryAttributeProjection;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,6 +13,8 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CategoryAttributeRepository extends JpaRepository<CategoryAttribute, Long> {
+
+    Optional<CategoryAttribute> findByIdAndCategoryId(Long id, Long categoryId);
 
     @Query("""
     SELECT new com.example.i_commerce.domain.product.repository.projection.CategoryAttributeProjection(

--- a/src/main/java/com/example/i_commerce/domain/product/repository/CategoryOptionRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/CategoryOptionRepository.java
@@ -4,6 +4,7 @@ import com.example.i_commerce.domain.product.entity.CategoryOption;
 import com.example.i_commerce.domain.product.repository.projection.CategoryOptionKey;
 import com.example.i_commerce.domain.product.repository.projection.CategoryOptionProjection;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,6 +13,8 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CategoryOptionRepository extends JpaRepository<CategoryOption, Long> {
+
+    Optional<CategoryOption> findByIdAndCategoryId(Long id, Long categoryId);
 
     List<CategoryOption> findAllByCategoryId(Long categoryId);
 

--- a/src/main/java/com/example/i_commerce/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/ProductRepository.java
@@ -25,6 +25,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             WHERE p.category.id IN :categoryIds
         ) THEN true ELSE false END
     """)
-    boolean existsActiveByCategoryIds(@Param("categoryIds") List<Long> categoryIds);
+    boolean existsByCategoryIds(@Param("categoryIds") List<Long> categoryIds);
 
 }

--- a/src/main/java/com/example/i_commerce/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/ProductRepository.java
@@ -1,6 +1,7 @@
 package com.example.i_commerce.domain.product.repository;
 
 import com.example.i_commerce.domain.product.entity.Product;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -17,4 +18,13 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
       WHERE p.id = :id
     """)
     Optional<Product> findByIdWithItemsAndStock(@Param("id") Long id);
+
+    @Query("""
+        SELECT CASE WHEN EXISTS (
+            SELECT 1 FROM Product p
+            WHERE p.category.id IN :categoryIds
+        ) THEN true ELSE false END
+    """)
+    boolean existsActiveByCategoryIds(@Param("categoryIds") List<Long> categoryIds);
+
 }

--- a/src/main/java/com/example/i_commerce/global/security/checker/AuthChecker.java
+++ b/src/main/java/com/example/i_commerce/global/security/checker/AuthChecker.java
@@ -142,7 +142,7 @@ public class AuthChecker {
     }
 
     // 시스템 옵션
-    public boolean canManageSystemOption() {
+    public boolean canManageOption() {
         return isAdmin()
             && has(SecurityAuthority.STATUS_ACTIVE)
             && hasAny(SecurityAuthority.ADMIN_MASTER,


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
- #118 

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
상품 도메인에서 삭제할 때 큰 영향이 없는 간단한 삭제 api를 만들었습니다.
- 옵션, 카테고리 옵션, 카테고리 속성 삭제, 카테고리 api
- 카테고리는 연결된 상품이 없는 경우만 삭제 가능

기타 작업
- 각 api에 관리자 권한 체크 추가 (전에 만들었던 api에도 추가)


## 😅 Uncompleted Tasks
[//]: # (없다면 N/A)
- [ ] 속성 삭제는 연관된 내용을 생각하며 좀 더 고민이 필요

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
- 현재 옵션 등은 이력이 크게 필요할까 싶고 각 유니크 제약때문에 hard delete로 했는데 더 고민해서 추후 유니크 제약에 deleted at 포함하는 방식으로 바꿀수도 있을 것 같습니다..
- 궁금하신 점 등 기타 의견 편하게 주세요~