### PR TITLE
refactor: 리뷰 도메인 의존성 분리

### DIFF
--- a/src/main/java/com/example/i_commerce/domain/product/application/service/ProductQueryService.java
+++ b/src/main/java/com/example/i_commerce/domain/product/application/service/ProductQueryService.java
@@ -45,8 +45,8 @@ public class ProductQueryService implements ProductQueryFacade {
             .orElseThrow(() -> new AppException(ProductErrorCode.PRODUCT_ITEM_NOT_FOUND));
     }
 
-    public List<Long> getProductIdsByStoreId(Long storeId) {
-        return productRepository.findAllIdsByStoreId(storeId);
+    public List<Long> getProductIdsByStoreIds(List<Long> storeIds) {
+        return productRepository.findAllIdsByStoreIds(storeIds);
     }
 
     @Override

--- a/src/main/java/com/example/i_commerce/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/ProductRepository.java
@@ -14,7 +14,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query("""
       SELECT p.id FROM Product p WHERE p.storeId IN :storeIds
     """)
-    List<Long> findAllIdsByStoreIds(@Param("storeId") List<Long> storeIds);
+    List<Long> findAllIdsByStoreIds(@Param("storeIds") List<Long> storeIds);
 
     @Query("""
       SELECT p FROM Product p

--- a/src/main/java/com/example/i_commerce/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/product/repository/ProductRepository.java
@@ -12,9 +12,9 @@ import org.springframework.stereotype.Repository;
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
     @Query("""
-      SELECT p.id FROM Product p WHERE p.storeId = :storeId
+      SELECT p.id FROM Product p WHERE p.storeId IN :storeIds
     """)
-    List<Long> findAllIdsByStoreId(@Param("storeId")Long storeId);
+    List<Long> findAllIdsByStoreIds(@Param("storeId") List<Long> storeIds);
 
     @Query("""
       SELECT p FROM Product p

--- a/src/main/java/com/example/i_commerce/domain/review/controller/SellerReviewController.java
+++ b/src/main/java/com/example/i_commerce/domain/review/controller/SellerReviewController.java
@@ -5,7 +5,6 @@ import com.example.i_commerce.domain.review.facade.ReviewLikeFacade;
 import com.example.i_commerce.domain.review.service.ReviewCommentService;
 import com.example.i_commerce.domain.review.service.ReviewService;
 import com.example.i_commerce.domain.review.service.dto.CreateCommentRequest;
-import com.example.i_commerce.domain.review.service.dto.ReviewCommentManagementResponse;
 import com.example.i_commerce.domain.review.service.dto.ReviewListResponse;
 import com.example.i_commerce.domain.review.service.dto.SellerReviewManagementResponse;
 import com.example.i_commerce.domain.review.service.dto.UpdateCommentRequest;
@@ -30,6 +29,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import com.example.i_commerce.global.common.response.SliceResponse;
+import org.springframework.data.domain.Pageable;
 
 @Tag(name = "Seller Review API", description = "판매자 리뷰 관리 API")
 @SecurityRequirement(name = "BearerAuth")
@@ -99,13 +100,13 @@ public class SellerReviewController {
         return ApiResponse.success(editedCommentId);
     }
 
-    @Operation(summary = "내가 단 답글 목록 조회", description = "판매자 본인이 작성한 모든 답글을 조회한다.")
-    @GetMapping("/comments")
-    public ApiResponse<List<SellerReviewManagementResponse>> getMyComments(
-        @AuthenticationPrincipal CustomUserPrincipal principal
+    @Operation(summary = "판매자 상점 리뷰 목록 조회", description = "판매자가 운영하는 상점에 등록된 모든 상품 리뷰를 페이징하여 조회한다.")
+    @GetMapping
+    public ApiResponse<SliceResponse<ReviewListResponse>> getSellerReviews(
+        @AuthenticationPrincipal CustomUserPrincipal principal,
+        Pageable pageable
     ) {
-        List<SellerReviewManagementResponse> responses = reviewCommentService.getReviewsForSeller(principal.getId());
-        return ApiResponse.success(responses);
+        SliceResponse<ReviewListResponse> response = reviewCommentService.getSellerReviews(principal.getId(), pageable);
+        return ApiResponse.success(response);
     }
-
 }

--- a/src/main/java/com/example/i_commerce/domain/review/entity/Review.java
+++ b/src/main/java/com/example/i_commerce/domain/review/entity/Review.java
@@ -48,6 +48,8 @@ public class Review extends BaseEntity {
     @Column(nullable = false)
     private Long productId;
 
+    private String displayOptionName;
+
     @Column(nullable = false)
     private Long userId;
 

--- a/src/main/java/com/example/i_commerce/domain/review/exception/ReviewErrorCode.java
+++ b/src/main/java/com/example/i_commerce/domain/review/exception/ReviewErrorCode.java
@@ -20,6 +20,7 @@ public enum ReviewErrorCode implements ErrorCode {
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REV-40907", "해당 리뷰를 찾을 수 없습니다."),
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REV-40908", "해당 신고를 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "REV-40912", "해당 답글을 찾을 수 없습니다."),
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "REV-40915", "리뷰 상품 데이터가 존재하지 않습니다."),
     NOT_ACTUAL_BUYER(HttpStatus.FORBIDDEN, "REV-40914", "주문 확정이 된 고객만 리뷰를 쓸 수 있습니다."),
     NOT_AUTHORIZED_ADMIN(HttpStatus.UNAUTHORIZED, "REV-40909", "해당 작업을 수행할 권한이 있는 관리자가 아닙니다.")
     ;

--- a/src/main/java/com/example/i_commerce/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/review/repository/ReviewRepository.java
@@ -19,28 +19,10 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     List<Review> findAllByOrderProductIdAndDeletedAtIsNull(Long orderProductId);
 
-    @Query("SELECT COUNT(r) > 0 FROM Review r " +
-        "JOIN OrderProduct op ON r.orderProductId = op.id " +
-        "JOIN ProductItem pi ON op.productSkuId = pi.id " +
-        "JOIN pi.product p " +
-        "JOIN Store s ON p.storeId = s.id " +
-        "WHERE r.id = :reviewId AND s.sellerId = :sellerId")
-    boolean existsByIdAndSellerId(@Param("reviewId") Long reviewId, @Param("sellerId") Long sellerId);
+    @Query("SELECT p.storeId FROM Product p WHERE p.id = :productId")
+    Long findStoreIdByProductId(@Param("productId") Long productId);
 
-    @Query("SELECT r FROM Review r " +
-        "JOIN OrderProduct op ON r.orderProductId = op.id " +
-        "JOIN ProductItem pi ON op.productSkuId = pi.id " +
-        "WHERE pi.product.id = :productId")
-    Slice<Review> findSliceByProductId(@Param("productId") Long productId, Pageable pageable);
-
-    @Query("SELECT r FROM Review r " +
-        "JOIN OrderProduct op ON r.orderProductId = op.id " +
-        "JOIN ProductItem pi ON op.productSkuId = pi.id " +
-        "JOIN pi.product p " +
-        "JOIN Store s ON p.storeId = s.id " +
-        "WHERE s.sellerId = :sellerId " +
-        "ORDER BY r.createdAt DESC")
-    List<SellerReviewManagementResponse> findAllBySellerId(@Param("sellerId") Long sellerId);
+    Slice<Review> findByProductId(@Param("productId") Long productId, Pageable pageable);
 
     @Query("SELECT COUNT(op) > 0 FROM OrderProduct op " +
         "JOIN op.order o " +
@@ -54,9 +36,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     );
 
     @Query("SELECT r FROM Review r " +
-        "JOIN OrderProduct op ON r.orderProductId = op.id " +
-        "JOIN ProductItem pi ON op.productSkuId = pi.id " +
-        "WHERE (:displayOptionName IS NULL OR pi.displayOptionName = :displayOptionName) " +
+        "WHERE (:displayOptionName IS NULL OR r.displayOptionName = :displayOptionName) " +
         "AND (:keyword IS NULL OR r.content LIKE CONCAT('%',:keyword, '%')) " +
         "AND (:starRate IS NULL OR r.starRate = :starRate)")
     Slice<Review> searchReviews(
@@ -72,5 +52,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         "GROUP BY r.starRate")
     List<StarRateCountProjection> getStarRateStats(@Param("productId") Long productId);
 
+    Slice<Review> findAllByProductIdIn(List<Long> productIds, Pageable pageable);
 }
 

--- a/src/main/java/com/example/i_commerce/domain/review/service/ReviewCommentService.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/ReviewCommentService.java
@@ -1,19 +1,27 @@
 package com.example.i_commerce.domain.review.service;
 
+import com.example.i_commerce.domain.member.service.member.MemberService;
+import com.example.i_commerce.domain.member.service.store.StoreService;
+import com.example.i_commerce.domain.member.service.store.dto.StoreResponse;
+import com.example.i_commerce.domain.product.application.service.ProductQueryService;
 import com.example.i_commerce.domain.review.entity.Review;
 import com.example.i_commerce.domain.review.entity.ReviewComment;
 import com.example.i_commerce.domain.review.exception.ReviewErrorCode;
 import com.example.i_commerce.domain.review.repository.ReviewCommentRepository;
 import com.example.i_commerce.domain.review.repository.ReviewRepository;
 import com.example.i_commerce.domain.review.service.dto.CreateCommentRequest;
+import com.example.i_commerce.domain.review.service.dto.ReviewListResponse;
 import com.example.i_commerce.domain.review.service.dto.SellerReviewManagementResponse;
 import com.example.i_commerce.domain.review.service.dto.UpdateCommentRequest;
 import com.example.i_commerce.domain.review.validator.ReviewForbiddenWordValidator;
+import com.example.i_commerce.global.common.response.SliceResponse;
 import com.example.i_commerce.global.exception.AppException;
 import com.example.i_commerce.global.exception.common.CommonErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +34,8 @@ public class ReviewCommentService {
     private final ReviewRepository reviewRepo;
     private final ReviewCommentRepository reviewCommentRepo;
     private final ReviewForbiddenWordValidator reviewForbiddenWordValidator;
+    private final StoreService storeService;
+    private final ProductQueryService productQueryService;
 
     @Transactional
     public void createComment(Long reviewId, Long sellerId, CreateCommentRequest request) {
@@ -33,7 +43,13 @@ public class ReviewCommentService {
         Review review = reviewRepo.findById(reviewId)
             .orElseThrow(() -> new AppException(ReviewErrorCode.REVIEW_NOT_FOUND));
 
-        if (!reviewRepo.existsByIdAndSellerId(reviewId, sellerId)) {
+        Long storeId = reviewRepo.findStoreIdByProductId(review.getProductId());
+
+        if (storeId == null) {
+            throw new AppException(ReviewErrorCode.PRODUCT_NOT_FOUND);
+        }
+
+        if (!storeService.isStoreManager(sellerId, storeId)) {
             throw new AppException(CommonErrorCode.INVALID_PERMISSION);
         }
 
@@ -41,12 +57,10 @@ public class ReviewCommentService {
             throw new AppException(ReviewErrorCode.ALREADY_COMMENTED);
         }
 
-
         reviewForbiddenWordValidator.validateContent(request.getContent());
         ReviewComment comment = ReviewComment.of(review, sellerId, request);
 
         reviewCommentRepo.save(comment);
-
     }
 
     @Transactional
@@ -65,9 +79,28 @@ public class ReviewCommentService {
         return commentId;
     }
 
-    @Transactional
-    public List<SellerReviewManagementResponse> getReviewsForSeller(Long sellerId) {
-        return reviewRepo.findAllBySellerId(sellerId);
+    @Transactional(readOnly = true)
+    public SliceResponse<ReviewListResponse> getSellerReviews(Long sellerId, Pageable pageable) {
+
+        List<StoreResponse> stores = storeService.getMyStores(sellerId);
+
+        if (stores == null || stores.isEmpty()) {
+            return SliceResponse.empty();
+        }
+
+        List<Long> storeIds = stores.stream()
+            .map(StoreResponse::storeId)
+            .toList();
+
+        List<Long> productIds = productQueryService.getProductIdsByStoreIds(storeIds);
+
+        if (productIds == null || productIds.isEmpty()) {
+            return SliceResponse.empty();
+        }
+
+        Slice<Review> reviews = reviewRepo.findAllByProductIdIn(productIds, pageable);
+
+        return SliceResponse.of(reviews, ReviewListResponse::from);
     }
 
 }

--- a/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
@@ -37,17 +37,17 @@ public class ReviewService {
 
     @Transactional
     public Long createReview(Long orderProductId, Long userId, CreateReviewRequest dto, List<MultipartFile> imageFiles) {
-        validateStarRating(dto.getStarRate());
 
-        if (!reviewRepo.isReviewableStatus(orderProductId, userId, OrderStatus.COMPLETED)) {
-            throw new AppException(ReviewErrorCode.NOT_ACTUAL_BUYER);
-        }
+        validateStarRating(dto.getStarRate());
+        reviewForbiddenWordValidator.validateContent(dto.getContent());
 
         if (reviewRepo.existsByOrderProductIdAndUserId(orderProductId, userId)) {
             throw new AppException(ReviewErrorCode.ALREADY_REVIEWED);
         }
 
-        reviewForbiddenWordValidator.validateContent(dto.getContent());
+        if (!reviewRepo.isReviewableStatus(orderProductId, userId, OrderStatus.COMPLETED)) {
+            throw new AppException(ReviewErrorCode.NOT_ACTUAL_BUYER);
+        }
 
         Review review = Review.from(orderProductId, userId, dto);
 
@@ -81,7 +81,7 @@ public class ReviewService {
     @Transactional(readOnly = true)
     public SliceResponse<ReviewListResponse> viewReviewList(Long productId, Pageable pageable) {
 
-        Slice<Review> reviewSlice = reviewRepo.findSliceByProductId(productId, pageable);
+        Slice<Review> reviewSlice = reviewRepo.findByProductId(productId, pageable);
 
         return SliceResponse.of(reviewSlice, ReviewListResponse::from);
     }

--- a/src/main/java/com/example/i_commerce/global/common/response/SliceResponse.java
+++ b/src/main/java/com/example/i_commerce/global/common/response/SliceResponse.java
@@ -36,4 +36,10 @@ public record SliceResponse<T>(
             slice.isLast()
         );
     }
+
+    public static <T> SliceResponse<T> empty() {
+        return SliceResponse.of(
+            new org.springframework.data.domain.SliceImpl<>(java.util.Collections.emptyList())
+        );
+    }
 }

--- a/src/test/java/com/example/i_commerce/domain/review/repository/ReviewLikeRepositoryTest.java
+++ b/src/test/java/com/example/i_commerce/domain/review/repository/ReviewLikeRepositoryTest.java
@@ -40,6 +40,8 @@ class ReviewLikeRepositoryTest {
             .content("정말 좋아유")
             .starRate(5)
             .likeCount(2L)
+            .productId(100L)
+            .displayOptionName("블랙")
             .bestStatus(ReviewIsBestStatus.NORMAL)
             .isExcluded(false)
             .build();

--- a/src/test/java/com/example/i_commerce/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/review/service/ReviewServiceTest.java
@@ -77,6 +77,8 @@ public class ReviewServiceTest {
         CreateReviewRequest request = new CreateReviewRequest("내 돈 내 산 리뷰", 5);
         List<MultipartFile> imageFiles = List.of();
 
+        given(reviewRepo.existsByOrderProductIdAndUserId(orderProductId, userId)).willReturn(false);
+
         given(reviewRepo.isReviewableStatus(orderProductId, userId, OrderStatus.COMPLETED))
             .willReturn(false);
 
@@ -86,7 +88,6 @@ public class ReviewServiceTest {
             .hasFieldOrPropertyWithValue("errorCode", ReviewErrorCode.NOT_ACTUAL_BUYER);
 
         verify(reviewRepo, never()).save(any(Review.class));
-        verify(reviewRepo, never()).existsByOrderProductIdAndUserId(anyLong(), anyLong());
     }
 
     @Test
@@ -99,10 +100,7 @@ public class ReviewServiceTest {
         CreateReviewRequest request = new CreateReviewRequest("리뷰 또 쓰고 싶다", 5);
         List<MultipartFile> imageFiles = List.of();
 
-        given(reviewRepo.isReviewableStatus(orderProductId, userId, OrderStatus.COMPLETED))
-            .willReturn(true);
-
-        given(reviewRepo.existsByOrderProductIdAndUserId(10L, 1L)).willReturn(true);
+        given(reviewRepo.existsByOrderProductIdAndUserId(orderProductId, userId)).willReturn(true);
 
         //when&then
         assertThatThrownBy(() -> reviewService.createReview(orderProductId, userId, request, imageFiles))
@@ -110,7 +108,6 @@ public class ReviewServiceTest {
             .hasFieldOrPropertyWithValue("errorCode", ReviewErrorCode.ALREADY_REVIEWED);
 
         verify(reviewRepo, never()).save(any(Review.class));
-
     }
 
     @Test


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
closed #131

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
- JOIN 쿼리 삭제 및 레포지토리 단일 조회 쿼리로 변경
- Review 엔티티에 productId, displayOptionName 컬럼 추가 


## 📢 To Reviewers
도메인 분리: 타 도메인(Member, Product)의 서비스를 직접 참조하던 구조를 서비스 계층 간 메서드 호출 및 레포지토리 쿼리로 변경해 의존성을 줄였습니다.

Product 도메인 연동: 상품(Product) 도메인의 PR이 아직 머지되지 않아, 테스트를 위해 해당 코드를 로컬 브랜치에 일시적으로 포함했습니다.(ProductQueryService, ProductRepository)
