### PR TITLE
refactor: 리뷰 도메인 의존성 분리(#133)

### DIFF
--- a/src/main/java/com/example/i_commerce/domain/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/example/i_commerce/domain/order/exception/OrderErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum OrderErrorCode implements ErrorCode {
     ORDER_NOT_OWNED(HttpStatus.FORBIDDEN, "ORD-40301", "해당 주문에 대한 권한이 없습니다."),
 
-    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORD-40401", "order를 찾을 수 없습니다.")
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORD-40401", "order를 찾을 수 없습니다."),
+    ORDER_PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "ORD-40402", "해당 주문 상품을 찾을 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/i_commerce/domain/order/repository/OrderProductRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/order/repository/OrderProductRepository.java
@@ -2,8 +2,14 @@ package com.example.i_commerce.domain.order.repository;
 
 import com.example.i_commerce.domain.order.entity.OrderProduct;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OrderProductRepository extends JpaRepository<OrderProduct, Long> {
     List<OrderProduct> findAllByOrderId(Long id);
+
+    @Query("SELECT op FROM OrderProduct op JOIN FETCH op.order WHERE op.id = :orderProductId")
+    Optional<OrderProduct> findByIdWithOrder(@Param("orderProductId") Long orderProductId);
 }

--- a/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
@@ -29,6 +29,7 @@ import com.example.i_commerce.domain.product.application.dto.StockDeductCommand;
 import com.example.i_commerce.domain.product.repository.ProductItemRepository;
 import com.example.i_commerce.global.common.response.ApiResponse;
 import com.example.i_commerce.global.exception.AppException;
+import com.example.i_commerce.global.exception.ErrorCode;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -167,5 +168,11 @@ public class OrderService {
         if (!order.getUserId().equals(userId)) {
             throw new AppException(OrderErrorCode.ORDER_NOT_OWNED);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public OrderProduct findOrderProductById(Long orderProductId) {
+        return orderProductRepository.findById(orderProductId)
+            .orElseThrow(() -> new AppException(OrderErrorCode.ORDER_PRODUCT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
@@ -21,6 +21,7 @@ import com.example.i_commerce.domain.order.service.dto.CreateOrderResponse;
 import com.example.i_commerce.domain.order.service.dto.OrderDetailResponse;
 import com.example.i_commerce.domain.order.service.dto.OrderDetailResponse.OrderProductDetail;
 import com.example.i_commerce.domain.order.service.dto.OrderDetailResponse.PaymentInfo;
+import com.example.i_commerce.domain.order.service.dto.OrderProductResponse;
 import com.example.i_commerce.domain.order.service.dto.OrderSummaryResponse;
 import com.example.i_commerce.domain.product.entity.ProductItem;
 import com.example.i_commerce.domain.product.exception.ProductErrorCode;
@@ -171,8 +172,14 @@ public class OrderService {
     }
 
     @Transactional(readOnly = true)
-    public OrderProduct findOrderProductById(Long orderProductId) {
-        return orderProductRepository.findById(orderProductId)
+    public OrderProductResponse getOrderProductForReview(Long orderProductId) {
+        OrderProduct orderProduct = orderProductRepository.findByIdWithOrder(orderProductId)
             .orElseThrow(() -> new AppException(OrderErrorCode.ORDER_PRODUCT_NOT_FOUND));
+
+        return new OrderProductResponse(
+            orderProduct.getProductSkuId(),
+            orderProduct.getOrder().getUserId(),
+            orderProduct.getOrder().getOrderStatus()
+        );
     }
 }

--- a/src/main/java/com/example/i_commerce/domain/order/service/dto/OrderProductResponse.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/dto/OrderProductResponse.java
@@ -1,0 +1,10 @@
+package com.example.i_commerce.domain.order.service.dto;
+
+import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
+
+public record OrderProductResponse(
+    Long productId,
+    Long userId,
+    OrderStatus orderStatus
+) {
+}

--- a/src/main/java/com/example/i_commerce/domain/review/controller/SellerReviewController.java
+++ b/src/main/java/com/example/i_commerce/domain/review/controller/SellerReviewController.java
@@ -47,9 +47,9 @@ public class SellerReviewController {
     @Operation(summary = "베스트 리뷰 후보 조회", description = "판매자는 베스트 리뷰 후보를 확인한다.")
     @GetMapping("/best-candidates")
     public ApiResponse<List<ReviewListResponse>> getBestReviewCandidates(
-        @RequestParam Long productOrderId
+        @RequestParam Long productId
     ) {
-        List<ReviewListResponse> responses = reviewService.getBestReviewCandidates(productOrderId);
+        List<ReviewListResponse> responses = reviewService.getBestReviewCandidates(productId);
 
         return ApiResponse.success(responses);
     }

--- a/src/main/java/com/example/i_commerce/domain/review/entity/Review.java
+++ b/src/main/java/com/example/i_commerce/domain/review/entity/Review.java
@@ -228,16 +228,19 @@ public class Review extends BaseEntity {
         this.reportStatus = reviewReportStatus;
     }
 
-    public static Review from(Long orderProductId, Long userId, CreateReviewRequest dto) {
+    public static Review from(Long orderProductId, Long userId, Long productId, CreateReviewRequest dto) {
         Review review = Review.builder()
             .orderProductId(orderProductId)
             .userId(userId)
+            .productId(productId)
             .content(dto.getContent())
             .starRate(dto.getStarRate())
             .likeCount(0L)
             .reportCount(0L)
+            .bestStatus(ReviewIsBestStatus.NORMAL)
             .isBest(false)
             .isUpdated(false)
+            .isExcluded(false)
             .images(new ArrayList<>())
             .build();
 

--- a/src/main/java/com/example/i_commerce/domain/review/exception/ReviewErrorCode.java
+++ b/src/main/java/com/example/i_commerce/domain/review/exception/ReviewErrorCode.java
@@ -17,6 +17,7 @@ public enum ReviewErrorCode implements ErrorCode {
     INVALID_SELF_REPORTING(HttpStatus.BAD_REQUEST, "REV-40905", "자신의 리뷰를 신고할 수 없습니다."),
     ADMIN_ID_REQUIRED(HttpStatus.BAD_REQUEST, "REV-40906", "관리자 ID는 필수입니다."),
     FORBIDDEN_WORD_INCLUDED(HttpStatus.BAD_REQUEST, "REV-40913", "금칙어가 포함되어 있습니다.") ,
+    REVIEW_NOT_ALLOWED_STATE(HttpStatus.BAD_REQUEST, "REV-40916", "구매 확정일 때만 리뷰 등록이 가능합니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REV-40907", "해당 리뷰를 찾을 수 없습니다."),
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REV-40908", "해당 신고를 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "REV-40912", "해당 답글을 찾을 수 없습니다."),

--- a/src/main/java/com/example/i_commerce/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/review/repository/ReviewRepository.java
@@ -15,25 +15,11 @@ import org.springframework.data.domain.Pageable;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    boolean existsByOrderProductIdAndUserId(Long orderProductId, Long userId);
+    boolean existsByOrderProductId(Long orderProductId);
 
-    List<Review> findAllByOrderProductIdAndDeletedAtIsNull(Long orderProductId);
-
-    @Query("SELECT p.storeId FROM Product p WHERE p.id = :productId")
-    Long findStoreIdByProductId(@Param("productId") Long productId);
+    List<Review> findAllByProductIdAndDeletedAtIsNull(Long productId);
 
     Slice<Review> findByProductId(@Param("productId") Long productId, Pageable pageable);
-
-    @Query("SELECT COUNT(op) > 0 FROM OrderProduct op " +
-        "JOIN op.order o " +
-        "WHERE op.id = :orderProductId " +
-        "AND o.userId = :userId " +
-        "AND o.orderStatus = :status")
-    boolean isReviewableStatus(
-        @Param("orderProductId") Long orderProductId,
-        @Param("userId") Long userId,
-        @Param("status") OrderStatus status
-    );
 
     @Query("SELECT r FROM Review r " +
         "WHERE (:displayOptionName IS NULL OR r.displayOptionName = :displayOptionName) " +

--- a/src/main/java/com/example/i_commerce/domain/review/service/ForbiddenWordAdminService.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/ForbiddenWordAdminService.java
@@ -12,8 +12,6 @@ public class ForbiddenWordAdminService {
 
     private final ReviewForbiddenWordRepository forbiddenWordRepository;
 
-    // 💡 금칙어를 새로 추가할 때, 기존에 저장된 "forbiddenWords" 캐시를 싹 비워줍니다.
-    // 그래야 다음 리뷰 검증 때 DB에서 최신 금칙어 목록을 다시 캐싱해 옵니다!
     @CacheEvict(value = "forbiddenWords", allEntries = true)
     public void addForbiddenWord(String word) {
         forbiddenWordRepository.save(new ReviewForbiddenWord(word));

--- a/src/main/java/com/example/i_commerce/domain/review/service/ReviewCommentService.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/ReviewCommentService.java
@@ -43,7 +43,7 @@ public class ReviewCommentService {
         Review review = reviewRepo.findById(reviewId)
             .orElseThrow(() -> new AppException(ReviewErrorCode.REVIEW_NOT_FOUND));
 
-        Long storeId = reviewRepo.findStoreIdByProductId(review.getProductId());
+        Long storeId = productQueryService.getStoreIdByProductId(review.getProductId());
 
         if (storeId == null) {
             throw new AppException(ReviewErrorCode.PRODUCT_NOT_FOUND);

--- a/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
@@ -3,6 +3,7 @@ package com.example.i_commerce.domain.review.service;
 import com.example.i_commerce.domain.order.entity.OrderProduct;
 import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
 import com.example.i_commerce.domain.order.service.OrderService;
+import com.example.i_commerce.domain.order.service.dto.OrderProductResponse;
 import com.example.i_commerce.domain.review.entity.Review;
 import com.example.i_commerce.domain.review.exception.ReviewErrorCode;
 import com.example.i_commerce.domain.review.repository.ReviewRepository;
@@ -48,17 +49,17 @@ public class ReviewService {
             throw new AppException(ReviewErrorCode.ALREADY_REVIEWED);
         }
 
-        OrderProduct orderProduct = orderService.findOrderProductById(orderProductId);
+        OrderProductResponse orderInfo = orderService.getOrderProductForReview(orderProductId);
 
-        if (!orderProduct.getOrder().getUserId().equals(userId)) {
+        if (!orderInfo.userId().equals(userId)) {
             throw new AppException(ReviewErrorCode.NOT_ACTUAL_BUYER);
         }
 
-        if (orderProduct.getOrder().getOrderStatus() != OrderStatus.COMPLETED) {
+        if (orderInfo.orderStatus() != OrderStatus.COMPLETED) {
             throw new AppException(ReviewErrorCode.REVIEW_NOT_ALLOWED_STATE);
         }
 
-        Long productId = orderProduct.getProductSkuId();
+        Long productId = orderInfo.productId();
 
         Review review = Review.from(orderProductId, userId, productId, dto);
         Review savedReview = reviewRepo.save(review);

--- a/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
@@ -60,7 +60,7 @@ public class ReviewService {
 
         Long productId = orderProduct.getProductSkuId();
 
-        Review review = Review.from(orderProductId, productId, userId, dto);
+        Review review = Review.from(orderProductId, userId, productId, dto);
         Review savedReview = reviewRepo.save(review);
 
         if (imageFiles != null && !imageFiles.isEmpty()) {

--- a/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
@@ -1,6 +1,8 @@
 package com.example.i_commerce.domain.review.service;
 
+import com.example.i_commerce.domain.order.entity.OrderProduct;
 import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
+import com.example.i_commerce.domain.order.service.OrderService;
 import com.example.i_commerce.domain.review.entity.Review;
 import com.example.i_commerce.domain.review.exception.ReviewErrorCode;
 import com.example.i_commerce.domain.review.repository.ReviewRepository;
@@ -34,6 +36,7 @@ public class ReviewService {
     private final ReviewRepository reviewRepo;
     private final ReviewForbiddenWordValidator reviewForbiddenWordValidator;
     private final S3ImageService s3ImageService;
+    private final OrderService orderService;
 
     @Transactional
     public Long createReview(Long orderProductId, Long userId, CreateReviewRequest dto, List<MultipartFile> imageFiles) {
@@ -41,16 +44,23 @@ public class ReviewService {
         validateStarRating(dto.getStarRate());
         reviewForbiddenWordValidator.validateContent(dto.getContent());
 
-        if (reviewRepo.existsByOrderProductIdAndUserId(orderProductId, userId)) {
+        if (reviewRepo.existsByOrderProductId(orderProductId)) {
             throw new AppException(ReviewErrorCode.ALREADY_REVIEWED);
         }
 
-        if (!reviewRepo.isReviewableStatus(orderProductId, userId, OrderStatus.COMPLETED)) {
+        OrderProduct orderProduct = orderService.findOrderProductById(orderProductId);
+
+        if (!orderProduct.getOrder().getUserId().equals(userId)) {
             throw new AppException(ReviewErrorCode.NOT_ACTUAL_BUYER);
         }
 
-        Review review = Review.from(orderProductId, userId, dto);
+        if (orderProduct.getOrder().getOrderStatus() != OrderStatus.COMPLETED) {
+            throw new AppException(ReviewErrorCode.REVIEW_NOT_ALLOWED_STATE);
+        }
 
+        Long productId = orderProduct.getProductSkuId();
+
+        Review review = Review.from(orderProductId, productId, userId, dto);
         Review savedReview = reviewRepo.save(review);
 
         if (imageFiles != null && !imageFiles.isEmpty()) {
@@ -159,9 +169,9 @@ public class ReviewService {
     }
 
     @Transactional
-    public List<ReviewListResponse> getBestReviewCandidates(Long orderProductId) {
+    public List<ReviewListResponse> getBestReviewCandidates(Long productId) {
 
-        List<Review> reviews = reviewRepo.findAllByOrderProductIdAndDeletedAtIsNull(orderProductId);
+        List<Review> reviews = reviewRepo.findAllByProductIdAndDeletedAtIsNull(productId);
 
         for (Review r : reviews) {
             r.updateBestStatus(false);

--- a/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
@@ -170,12 +170,8 @@ public class ReviewService {
 
     @Transactional
     public List<ReviewListResponse> getBestReviewCandidates(Long productId) {
-
         List<Review> reviews = reviewRepo.findAllByProductIdAndDeletedAtIsNull(productId);
-
-        for (Review r : reviews) {
-            r.updateBestStatus(false);
-        }
+        reviews.removeIf(Review::isExcluded);
 
         reviews.sort((r1, r2) -> Double.compare(r2.calculateRecommendationScore(),
             r1.calculateRecommendationScore()));
@@ -186,10 +182,7 @@ public class ReviewService {
         for (int i = 0; i < limit; i++) {
             Review review = reviews.get(i);
 
-            review.updateBestStatus(true);
-
-            responses.add(ReviewListResponse.from(review));
-
+            responses.add(ReviewListResponse.ofCandidate(review));
         }
         return responses;
     }

--- a/src/main/java/com/example/i_commerce/domain/review/service/dto/ReviewListResponse.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/dto/ReviewListResponse.java
@@ -1,6 +1,7 @@
 package com.example.i_commerce.domain.review.service.dto;
 
 import com.example.i_commerce.domain.review.entity.Review;
+import com.example.i_commerce.domain.review.entity.enums.ReviewIsBestStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,6 +27,8 @@ public class ReviewListResponse {
 
     private Long likeCount;
 
+    private ReviewIsBestStatus bestStatus;
+
     public static ReviewListResponse from(Review review) {
 
         String firstUrl = (review.getImages() != null && !review.getImages().isEmpty())
@@ -39,6 +42,23 @@ public class ReviewListResponse {
             .starRate(review.getStarRate())
             .likeCount(review.getLikeCount())
             .firstImageUrl(firstUrl)
+            .isBest(review.getIsBest())
+            .build();
+    }
+
+    public static ReviewListResponse ofCandidate(Review review) {
+        String firstUrl = (review.getImages() != null && !review.getImages().isEmpty())
+            ? review.getImages().get(0).getImageUrl()
+            : null;
+
+        return ReviewListResponse.builder()
+            .reviewId(review.getId())
+            .userId(review.getUserId())
+            .content(review.getContent())
+            .starRate(review.getStarRate())
+            .likeCount(review.getLikeCount())
+            .firstImageUrl(firstUrl)
+            .bestStatus(ReviewIsBestStatus.BEST)
             .isBest(review.getIsBest())
             .build();
     }

--- a/src/test/java/com/example/i_commerce/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/review/service/ReviewServiceTest.java
@@ -5,15 +5,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.example.i_commerce.domain.order.entity.Order;
-import com.example.i_commerce.domain.order.entity.OrderProduct;
 import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
 import com.example.i_commerce.domain.order.service.OrderService;
+import com.example.i_commerce.domain.order.service.dto.OrderProductResponse;
 import com.example.i_commerce.domain.review.entity.Review;
 import com.example.i_commerce.domain.review.exception.ReviewErrorCode;
 import com.example.i_commerce.domain.review.repository.ReviewRepository;
@@ -62,15 +60,8 @@ public class ReviewServiceTest {
 
         given(reviewRepo.existsByOrderProductId(orderProductId)).willReturn(false);
 
-        Order mockOrder = mock(Order.class);
-        OrderProduct mockOrderProduct = mock(OrderProduct.class);
-
-        given(mockOrder.getUserId()).willReturn(userId);
-        given(mockOrder.getOrderStatus()).willReturn(OrderStatus.COMPLETED);
-        given(mockOrderProduct.getOrder()).willReturn(mockOrder);
-        given(mockOrderProduct.getProductSkuId()).willReturn(productId);
-
-        given(orderService.findOrderProductById(orderProductId)).willReturn(mockOrderProduct);
+        OrderProductResponse mockResponse = new OrderProductResponse(productId, userId, OrderStatus.COMPLETED);
+        given(orderService.getOrderProductForReview(orderProductId)).willReturn(mockResponse);
 
         Review mockReview = Review.builder().id(reviewId).build();
         given(reviewRepo.save(any(Review.class))).willReturn(mockReview);
@@ -89,19 +80,14 @@ public class ReviewServiceTest {
         // given
         Long userId = 1L;
         Long orderProductId = 10L;
+        Long productId = 99L;
         CreateReviewRequest request = new CreateReviewRequest("내 돈 내 산 리뷰", 5);
         List<MultipartFile> imageFiles = List.of();
 
         given(reviewRepo.existsByOrderProductId(orderProductId)).willReturn(false);
 
-        Order mockOrder = mock(Order.class);
-        OrderProduct mockOrderProduct = mock(OrderProduct.class);
-
-        given(mockOrder.getUserId()).willReturn(userId);
-        given(mockOrder.getOrderStatus()).willReturn(OrderStatus.PENDING); // ⭐️ 예외 발생 지점
-        given(mockOrderProduct.getOrder()).willReturn(mockOrder);
-
-        given(orderService.findOrderProductById(orderProductId)).willReturn(mockOrderProduct);
+        OrderProductResponse mockResponse = new OrderProductResponse(productId, userId, OrderStatus.PENDING);
+        given(orderService.getOrderProductForReview(orderProductId)).willReturn(mockResponse);
 
         // when & then
         assertThatThrownBy(() -> reviewService.createReview(orderProductId, userId, request, imageFiles))
@@ -129,7 +115,8 @@ public class ReviewServiceTest {
             .hasFieldOrPropertyWithValue("errorCode", ReviewErrorCode.ALREADY_REVIEWED);
 
         verify(reviewRepo, never()).save(any(Review.class));
-        verify(orderService, never()).findOrderProductById(anyLong());
+
+        verify(orderService, never()).getOrderProductForReview(anyLong());
     }
 
     @Test

--- a/src/test/java/com/example/i_commerce/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/review/service/ReviewServiceTest.java
@@ -5,11 +5,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.example.i_commerce.domain.order.entity.Order;
+import com.example.i_commerce.domain.order.entity.OrderProduct;
 import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
+import com.example.i_commerce.domain.order.service.OrderService;
 import com.example.i_commerce.domain.review.entity.Review;
 import com.example.i_commerce.domain.review.exception.ReviewErrorCode;
 import com.example.i_commerce.domain.review.repository.ReviewRepository;
@@ -32,6 +36,9 @@ public class ReviewServiceTest {
     @Mock
     private ReviewRepository reviewRepo;
 
+    @Mock
+    private OrderService orderService;
+
     @InjectMocks
     private ReviewService reviewService;
 
@@ -48,14 +55,22 @@ public class ReviewServiceTest {
         Long userId = 1L;
         Long orderProductId = 10L;
         Long reviewId = 100L;
+        Long productId = 99L;
 
         CreateReviewRequest request = new CreateReviewRequest("굳굳", 5);
         List<MultipartFile> imageFiles = List.of();
 
-        given(reviewRepo.isReviewableStatus(orderProductId, userId, OrderStatus.COMPLETED))
-            .willReturn(true);
+        given(reviewRepo.existsByOrderProductId(orderProductId)).willReturn(false);
 
-        given(reviewRepo.existsByOrderProductIdAndUserId(10L, 1L)).willReturn(false);
+        Order mockOrder = mock(Order.class);
+        OrderProduct mockOrderProduct = mock(OrderProduct.class);
+
+        given(mockOrder.getUserId()).willReturn(userId);
+        given(mockOrder.getOrderStatus()).willReturn(OrderStatus.COMPLETED);
+        given(mockOrderProduct.getOrder()).willReturn(mockOrder);
+        given(mockOrderProduct.getProductSkuId()).willReturn(productId);
+
+        given(orderService.findOrderProductById(orderProductId)).willReturn(mockOrderProduct);
 
         Review mockReview = Review.builder().id(reviewId).build();
         given(reviewRepo.save(any(Review.class))).willReturn(mockReview);
@@ -77,15 +92,21 @@ public class ReviewServiceTest {
         CreateReviewRequest request = new CreateReviewRequest("내 돈 내 산 리뷰", 5);
         List<MultipartFile> imageFiles = List.of();
 
-        given(reviewRepo.existsByOrderProductIdAndUserId(orderProductId, userId)).willReturn(false);
+        given(reviewRepo.existsByOrderProductId(orderProductId)).willReturn(false);
 
-        given(reviewRepo.isReviewableStatus(orderProductId, userId, OrderStatus.COMPLETED))
-            .willReturn(false);
+        Order mockOrder = mock(Order.class);
+        OrderProduct mockOrderProduct = mock(OrderProduct.class);
+
+        given(mockOrder.getUserId()).willReturn(userId);
+        given(mockOrder.getOrderStatus()).willReturn(OrderStatus.PENDING); // ⭐️ 예외 발생 지점
+        given(mockOrderProduct.getOrder()).willReturn(mockOrder);
+
+        given(orderService.findOrderProductById(orderProductId)).willReturn(mockOrderProduct);
 
         // when & then
         assertThatThrownBy(() -> reviewService.createReview(orderProductId, userId, request, imageFiles))
             .isInstanceOf(AppException.class)
-            .hasFieldOrPropertyWithValue("errorCode", ReviewErrorCode.NOT_ACTUAL_BUYER);
+            .hasFieldOrPropertyWithValue("errorCode", ReviewErrorCode.REVIEW_NOT_ALLOWED_STATE);
 
         verify(reviewRepo, never()).save(any(Review.class));
     }
@@ -100,7 +121,7 @@ public class ReviewServiceTest {
         CreateReviewRequest request = new CreateReviewRequest("리뷰 또 쓰고 싶다", 5);
         List<MultipartFile> imageFiles = List.of();
 
-        given(reviewRepo.existsByOrderProductIdAndUserId(orderProductId, userId)).willReturn(true);
+        given(reviewRepo.existsByOrderProductId(orderProductId)).willReturn(true);
 
         //when&then
         assertThatThrownBy(() -> reviewService.createReview(orderProductId, userId, request, imageFiles))
@@ -108,13 +129,13 @@ public class ReviewServiceTest {
             .hasFieldOrPropertyWithValue("errorCode", ReviewErrorCode.ALREADY_REVIEWED);
 
         verify(reviewRepo, never()).save(any(Review.class));
+        verify(orderService, never()).findOrderProductById(anyLong());
     }
 
     @Test
     @DisplayName("실패: 별점이 1점 미만 혹은 5점 초과면 예외가 발생한다")
     void createReview_Fail_InvalidStarRating(){
         //given
-
         Long userId = 1L;
         Long orderProductId = 10L;
 
@@ -126,8 +147,7 @@ public class ReviewServiceTest {
             .isInstanceOf(AppException.class)
             .hasFieldOrPropertyWithValue("errorCode", ReviewErrorCode.INVALID_STAR_RATING);
 
-        verify(reviewRepo, never()).existsByOrderProductIdAndUserId(anyLong(), anyLong());
+        verify(reviewRepo, never()).existsByOrderProductId(anyLong());
         verify(reviewRepo, never()).save(any(Review.class));
     }
-
 }


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
closed #133

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
- 리뷰 생성 검증(구매 확정 상태, 소유권)을 OrderService로부터 OrderProduct 엔티티를 반환받아 서비스에서 직접 처리
- ReviewRepository에서 타 도메인(Order, Product)의 복잡한 쿼리 제거
- 리뷰 답글 작성 시 ReviewRepository가 아닌 ProductQueryService를 호출해 StoreId를 조회

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
- 수정해야 할 부분 말씀해 주시면 감사하겠습니다!
