### PR TITLE
Test: 테스트 커버리지 확인을 위한 Jacoco 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '4.0.5'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
 }
 
 group = 'com.example'
@@ -79,4 +80,28 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
     jvmArgs("-XX:+EnableDynamicAgentLoading")
+    finalizedBy tasks.jacocoTestReport
+    //ignoreFailures = true
+}
+
+tasks.named('jacocoTestReport', JacocoReport)  {
+    dependsOn tasks.test
+
+    executionData.setFrom(
+            fileTree(layout.buildDirectory).include("jacoco/*.exec")
+    )
+
+    sourceDirectories.setFrom(files("src/main/java"))
+    classDirectories.setFrom(
+            fileTree("build/classes/java/main") {
+                include "**/service/**"
+                include "**/entity/**"
+            }
+    )
+
+    reports {
+        html.required = true
+        xml.required = false
+        csv.required = false
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -93,9 +93,12 @@ tasks.named('jacocoTestReport', JacocoReport)  {
 
     sourceDirectories.setFrom(files("src/main/java"))
     classDirectories.setFrom(
-            fileTree("build/classes/java/main") {
+            fileTree(layout.buildDirectory.dir("classes/java/main")) {
                 include "**/service/**"
                 include "**/entity/**"
+                exclude "**/dto/**"
+                exclude "**/config/**"
+                exclude "**/Q*.class"
             }
     )
 


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
- closed #140 -> develop

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
테스트 커버리지 확인을 위해 jacoco 설정을 추가했습니다.

다음 두 유형의 클래스만 확인되도록 설정했습니다.
- service
- entity

<img width="1064" height="275" alt="image" src="https://github.com/user-attachments/assets/f78efa77-c696-414a-9a5a-b795d8d3f8f5" />


## 😅 Uncompleted Tasks
- 현재 작성된 테스트코드 중 실패하는 케이스가 있어서 원래 report가 생성되지 않는데, 확인을 위해 `ignoreFailures = true`를 작성해 확인했습니다. 오류가 나는 테스트를 고친 후 삭제해야 합니다. (현재는 주석 처리)
- 나중에 AWS 배포 설정할 때는 `xml.required = true`로 변경이 필요합니다.

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
- `./gradlew clean test jacocoTestReport` 명령어를 실행해 확인할 수 있습니다.
- 테스트 커버리지 확인은 위 명령어 실행 후 `/build/reports/jacoco/test/html/index.html`를 여셔서 확인하실 수 있습니다.
- 현재 service와 entity만 커버리지 확인이 되도록 했는데, 이와 관련해서 추가로 의견 있으시면 말씀해 주세요!