### PR TITLE
Refactor/#138 review image 

### DIFF
--- a/src/main/java/com/example/i_commerce/domain/review/controller/OrderProductReviewController.java
+++ b/src/main/java/com/example/i_commerce/domain/review/controller/OrderProductReviewController.java
@@ -8,11 +8,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,6 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
 @SecurityRequirement(name = "BearerAuth")
 @RestController
 @RequiredArgsConstructor
+@Validated
 @RequestMapping("/api/v1/order-products")
 public class OrderProductReviewController {
 
@@ -39,7 +42,10 @@ public class OrderProductReviewController {
         @PathVariable Long orderProductId,
         @AuthenticationPrincipal CustomUserPrincipal principal,
         @RequestPart(value = "review") @Valid CreateReviewRequest request,
-        @RequestPart(value = "images", required = false) List<MultipartFile> imageFiles
+
+        @Size(max = 10, message = "이미지는 최대 10까지 업로드할 수 있습니다.")
+        @RequestPart(value = "images", required = false)
+        List<MultipartFile> imageFiles
     ) {
         Long createdReviewId = reviewService.createReview(orderProductId, principal.getId(), request, imageFiles);
         return ApiResponse.success(createdReviewId);

--- a/src/main/java/com/example/i_commerce/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/i_commerce/domain/review/controller/ReviewController.java
@@ -16,6 +16,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -32,8 +34,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Review API", description = "리뷰 관련 API")
 @SecurityRequirement(name = "BearerAuth")
@@ -89,8 +93,10 @@ public class ReviewController {
     public ApiResponse<Long> editReview(
         @PathVariable Long reviewId,
         @AuthenticationPrincipal CustomUserPrincipal principal,
-        @RequestBody @Valid UpdateReviewRequest dto) {
-        Long editedReviewId = reviewService.editReview(reviewId, principal.getId(), dto);
+        @RequestPart(value = "review") @Valid UpdateReviewRequest dto,
+        @Size(max = 10, message = "이미지는 최대 10장까지 업로드할 수 있습니다.")
+        @RequestPart(value = "images", required = false) List<MultipartFile> imageFiles) {
+        Long editedReviewId = reviewService.editReview(reviewId, principal.getId(), dto, imageFiles);
         return ApiResponse.success(editedReviewId);
     }
 

--- a/src/main/java/com/example/i_commerce/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/i_commerce/domain/review/controller/ReviewController.java
@@ -25,6 +25,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -43,6 +44,7 @@ import org.springframework.web.multipart.MultipartFile;
 @SecurityRequirement(name = "BearerAuth")
 @RestController
 @RequiredArgsConstructor
+@Validated
 @RequestMapping("/api/v1/reviews")
 public class ReviewController {
 

--- a/src/main/java/com/example/i_commerce/domain/review/exception/ReviewErrorCode.java
+++ b/src/main/java/com/example/i_commerce/domain/review/exception/ReviewErrorCode.java
@@ -13,16 +13,21 @@ public enum ReviewErrorCode implements ErrorCode {
     ALREADY_REPORT(HttpStatus.CONFLICT, "REV-40903", "이미 신고를 한 상품입니다."),
     ALREADY_PROCESSED(HttpStatus.CONFLICT, "REV-40911", "이미 처리가 완료된 신고 리뷰입니다."),
     ALREADY_ASSIGNED_ADMIN(HttpStatus.CONFLICT, "REV-40910", "이미 관리자가 배정되어있습니다."),
+
     INVALID_STAR_RATING(HttpStatus.BAD_REQUEST, "REV-40904", "별점은 1~5점 사이여야 합니다."),
     INVALID_SELF_REPORTING(HttpStatus.BAD_REQUEST, "REV-40905", "자신의 리뷰를 신고할 수 없습니다."),
     ADMIN_ID_REQUIRED(HttpStatus.BAD_REQUEST, "REV-40906", "관리자 ID는 필수입니다."),
     FORBIDDEN_WORD_INCLUDED(HttpStatus.BAD_REQUEST, "REV-40913", "금칙어가 포함되어 있습니다.") ,
     REVIEW_NOT_ALLOWED_STATE(HttpStatus.BAD_REQUEST, "REV-40916", "구매 확정일 때만 리뷰 등록이 가능합니다."),
+    EXCEED_MAX_IMAGE_COUNT(HttpStatus.BAD_REQUEST, "REV-40917", "사진은 최대 10장까지 올릴 수 있습니다."),
+
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REV-40907", "해당 리뷰를 찾을 수 없습니다."),
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REV-40908", "해당 신고를 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "REV-40912", "해당 답글을 찾을 수 없습니다."),
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "REV-40915", "리뷰 상품 데이터가 존재하지 않습니다."),
+
     NOT_ACTUAL_BUYER(HttpStatus.FORBIDDEN, "REV-40914", "주문 확정이 된 고객만 리뷰를 쓸 수 있습니다."),
+
     NOT_AUTHORIZED_ADMIN(HttpStatus.UNAUTHORIZED, "REV-40909", "해당 작업을 수행할 권한이 있는 관리자가 아닙니다.")
     ;
 

--- a/src/main/java/com/example/i_commerce/domain/review/exception/ReviewErrorCode.java
+++ b/src/main/java/com/example/i_commerce/domain/review/exception/ReviewErrorCode.java
@@ -20,6 +20,7 @@ public enum ReviewErrorCode implements ErrorCode {
     FORBIDDEN_WORD_INCLUDED(HttpStatus.BAD_REQUEST, "REV-40913", "금칙어가 포함되어 있습니다.") ,
     REVIEW_NOT_ALLOWED_STATE(HttpStatus.BAD_REQUEST, "REV-40916", "구매 확정일 때만 리뷰 등록이 가능합니다."),
     EXCEED_MAX_IMAGE_COUNT(HttpStatus.BAD_REQUEST, "REV-40917", "사진은 최대 10장까지 올릴 수 있습니다."),
+    UNMATCHED_REVIEW_IMAGE(HttpStatus.BAD_REQUEST, "REV-40918", "요청하신 이미지 중 해당 리뷰에 등록되지 않은 이미지가 포함되어 있습니다."),
 
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REV-40907", "해당 리뷰를 찾을 수 없습니다."),
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REV-40908", "해당 신고를 찾을 수 없습니다."),

--- a/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
@@ -62,9 +62,9 @@ public class ReviewService {
         Long productId = orderInfo.productId();
 
         Review review = Review.from(orderProductId, userId, productId, dto);
-        Review savedReview = reviewRepo.save(review);
 
         if (imageFiles != null && !imageFiles.isEmpty()) {
+
             for (MultipartFile file : imageFiles) {
                 if (!file.isEmpty()) {
                     String imageUrl = s3ImageService.uploadImage(file, "reviews");
@@ -72,6 +72,8 @@ public class ReviewService {
                 }
             }
         }
+
+        Review savedReview = reviewRepo.save(review);
 
         return savedReview.getId();
     }

--- a/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
@@ -160,7 +160,11 @@ public class ReviewService {
 
         List<String> finalImageUrls = new ArrayList<>();
 
-        if (dto.getImageUrls() != null && !dto.getImageUrls().isEmpty()) {
+        if (dto.getImageUrls() == null) {
+            finalImageUrls.addAll(review.getImages().stream()
+                .map(ReviewImage::getImageUrl)
+                .toList());
+        } else {
             finalImageUrls.addAll(dto.getImageUrls());
         }
 

--- a/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
@@ -5,6 +5,7 @@ import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
 import com.example.i_commerce.domain.order.service.OrderService;
 import com.example.i_commerce.domain.order.service.dto.OrderProductResponse;
 import com.example.i_commerce.domain.review.entity.Review;
+import com.example.i_commerce.domain.review.entity.ReviewImage;
 import com.example.i_commerce.domain.review.exception.ReviewErrorCode;
 import com.example.i_commerce.domain.review.repository.ReviewRepository;
 import com.example.i_commerce.domain.review.repository.StarRateCountProjection;
@@ -151,13 +152,33 @@ public class ReviewService {
     }
 
     @Transactional
-    public Long editReview(Long reviewId, Long userId, UpdateReviewRequest dto) {
+    public Long editReview(Long reviewId, Long userId, UpdateReviewRequest dto, List<MultipartFile> newImageFiles) {
         Review review = getReviewOrThrow(reviewId);
 
         validateAuthor(review, userId);
         reviewForbiddenWordValidator.validateContent(dto.getContent());
 
-        review.update(dto.getContent(), dto.getStarRate(), dto.getImageUrls());
+        List<String> finalImageUrls = new ArrayList<>();
+
+        if (dto.getImageUrls() != null && !dto.getImageUrls().isEmpty()) {
+            finalImageUrls.addAll(dto.getImageUrls());
+        }
+
+        review.getImages().stream()
+            .map(ReviewImage::getImageUrl)
+            .filter(oldUrl -> !finalImageUrls.contains(oldUrl))
+            .forEach(url -> s3ImageService.deleteImage(url));
+
+        if (newImageFiles != null && !newImageFiles.isEmpty()) {
+            for (MultipartFile file : newImageFiles) {
+                if (!file.isEmpty()) {
+                    String uploadedUrl = s3ImageService.uploadImage(file, "reviews");
+                    finalImageUrls.add(uploadedUrl);
+                }
+            }
+        }
+
+        review.update(dto.getContent(), dto.getStarRate(), finalImageUrls);
 
         return reviewId;
     }

--- a/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
@@ -168,7 +168,11 @@ public class ReviewService {
 
         validateAuthor(review, userId);
 
-        review.delete();
+        if (review.getImages() != null && !review.getImages().isEmpty()) {
+            review.getImages().forEach(image -> s3ImageService.deleteImage(image.getImageUrl()));
+        }
+
+        reviewRepo.delete(review);
     }
 
     @Transactional

--- a/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
@@ -158,13 +158,20 @@ public class ReviewService {
         validateAuthor(review, userId);
         reviewForbiddenWordValidator.validateContent(dto.getContent());
 
+        List<String> originalImageUrls = review.getImages().stream()
+            .map(ReviewImage::getImageUrl)
+            .toList();
+
         List<String> finalImageUrls = new ArrayList<>();
 
         if (dto.getImageUrls() == null) {
-            finalImageUrls.addAll(review.getImages().stream()
-                .map(ReviewImage::getImageUrl)
-                .toList());
+            finalImageUrls.addAll(originalImageUrls);
         } else {
+            for (String requestUrl : dto.getImageUrls()) {
+                if (!originalImageUrls.contains(requestUrl)) {
+                    throw new AppException(ReviewErrorCode.UNMATCHED_REVIEW_IMAGE);
+                }
+            }
             finalImageUrls.addAll(dto.getImageUrls());
         }
 

--- a/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
@@ -168,6 +168,15 @@ public class ReviewService {
             finalImageUrls.addAll(dto.getImageUrls());
         }
 
+        long newImageCount = 0;
+        if (newImageFiles != null) {
+            newImageCount = newImageFiles.stream().filter(file -> !file.isEmpty()).count();
+        }
+
+        if (finalImageUrls.size() + newImageCount > 10) {
+            throw new AppException(ReviewErrorCode.EXCEED_MAX_IMAGE_COUNT);
+        }
+
         review.getImages().stream()
             .map(ReviewImage::getImageUrl)
             .filter(oldUrl -> !finalImageUrls.contains(oldUrl))

--- a/src/main/java/com/example/i_commerce/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/i_commerce/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.example.i_commerce.global.exception;
 
 import com.example.i_commerce.global.common.response.ApiResponse;
 import com.example.i_commerce.global.exception.common.CommonErrorCode;
+import jakarta.validation.ConstraintViolationException;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
@@ -55,5 +56,16 @@ public class GlobalExceptionHandler {
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(ApiResponse.error(CommonErrorCode.INTERNAL_SERVER_ERROR, e.getMessage()));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<?>> handleConstraintViolationException(
+        ConstraintViolationException e) {
+
+        String errorMessage = e.getConstraintViolations().iterator().next().getMessage();
+
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error(CommonErrorCode.INVALID_INPUT_VALUE, e.getMessage()));
     }
 }

--- a/src/main/java/com/example/i_commerce/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/i_commerce/global/exception/GlobalExceptionHandler.java
@@ -66,6 +66,6 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
-            .body(ApiResponse.error(CommonErrorCode.INVALID_INPUT_VALUE, e.getMessage()));
+            .body(ApiResponse.error(CommonErrorCode.INVALID_INPUT_VALUE, errorMessage));
     }
 }


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
closed #138

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
- 리뷰 이미지 개수 제한 로직 추가
    - @Size를 사용해 최대 10장 제한
    - 컨트롤러에서 10장 초과되면 예외 처리
- 리뷰 조회 시 이미지 누락
    - 리뷰 생성 시 엔티티가 먼저 저장되어 더티체킹이 안 되는 문제 해결
    - s3 업로드, 엔티티 조립 완료 후 save를 호출해 review_images DB에 저장
- 리뷰 삭제 시 s3 이미지 삭제
- 리뷰 수정 시 기존 이미지 삭제 및 수정 이미지 업데이트

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
- 수정해야 할 부분 말씀해 주시면 감사하겠습니다.

