### PR TITLE
feat: 리뷰 무한뎁스 답글 구현(#158)

### DIFF
--- a/src/main/java/com/example/i_commerce/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/i_commerce/domain/review/controller/ReviewController.java
@@ -141,7 +141,7 @@ public class ReviewController {
     }
 
     @Operation(summary = "리뷰 답글 생성", description = "사용자는 특정 리뷰에 답글을 달 수 있다.")
-    @PostMapping("/{reviewId}/comment")
+    @PostMapping("/{reviewId}/comments")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<Void> createComment(
         @PathVariable Long reviewId,

--- a/src/main/java/com/example/i_commerce/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/i_commerce/domain/review/controller/ReviewController.java
@@ -1,13 +1,16 @@
 package com.example.i_commerce.domain.review.controller;
 
 import com.example.i_commerce.domain.review.facade.ReviewLikeFacade;
+import com.example.i_commerce.domain.review.service.ReviewCommentService;
 import com.example.i_commerce.domain.review.service.ReviewReportService;
 import com.example.i_commerce.domain.review.service.ReviewService;
+import com.example.i_commerce.domain.review.service.dto.CreateCommentRequest;
 import com.example.i_commerce.domain.review.service.dto.CreateReportRequest;
 import com.example.i_commerce.domain.review.service.dto.ReviewListResponse;
 import com.example.i_commerce.domain.review.service.dto.ReviewResponse;
 import com.example.i_commerce.domain.review.service.dto.ReviewStatsResponse;
 import com.example.i_commerce.domain.review.service.dto.SearchReviewRequest;
+import com.example.i_commerce.domain.review.service.dto.UpdateCommentRequest;
 import com.example.i_commerce.domain.review.service.dto.UpdateReviewRequest;
 import com.example.i_commerce.global.common.response.ApiResponse;
 import com.example.i_commerce.global.common.response.SliceResponse;
@@ -51,6 +54,7 @@ public class ReviewController {
     private final ReviewService reviewService;
     private final ReviewLikeFacade reviewLikeFacade;
     private final ReviewReportService reviewReportService;
+    private final ReviewCommentService reviewCommentService;
 
     @Operation(summary = "리뷰 목록 보기", description = "특정 상품에 대한 전체 리뷰를 본다.")
     @GetMapping
@@ -134,6 +138,28 @@ public class ReviewController {
     ) {
         reviewReportService.createReviewReport(reviewId, principal.getId(), dto);
         return ApiResponse.success();
+    }
+
+    @Operation(summary = "리뷰 답글 생성", description = "사용자는 특정 리뷰에 답글을 달 수 있다.")
+    @PostMapping("/{reviewId}/comment")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<Void> createComment(
+        @PathVariable Long reviewId,
+        @AuthenticationPrincipal CustomUserPrincipal principal,
+        @RequestBody @Valid CreateCommentRequest request) {
+        reviewCommentService.createComment(reviewId, principal.getId(), request);
+        return ApiResponse.success();
+    }
+
+    @Operation(summary = "리뷰 답글 수정", description = "사용자는 자신이 단 답글을 수정할 수 있다.")
+    @PatchMapping("/comments/{commentId}")
+    public ApiResponse<Long> editComment(
+        @PathVariable Long commentId,
+        @AuthenticationPrincipal CustomUserPrincipal principal,
+        @RequestBody @Valid UpdateCommentRequest request
+    ) {
+        Long editedCommentId = reviewCommentService.editComment(commentId, principal.getId(), request);
+        return ApiResponse.success(editedCommentId);
     }
 
 }

--- a/src/main/java/com/example/i_commerce/domain/review/controller/SellerReviewController.java
+++ b/src/main/java/com/example/i_commerce/domain/review/controller/SellerReviewController.java
@@ -47,9 +47,10 @@ public class SellerReviewController {
     @Operation(summary = "베스트 리뷰 후보 조회", description = "판매자는 베스트 리뷰 후보를 확인한다.")
     @GetMapping("/best-candidates")
     public ApiResponse<List<ReviewListResponse>> getBestReviewCandidates(
-        @RequestParam Long productId
+        @RequestParam Long productId,
+        @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
-        List<ReviewListResponse> responses = reviewService.getBestReviewCandidates(productId);
+        List<ReviewListResponse> responses = reviewService.getBestReviewCandidates(productId, principal.getId());
 
         return ApiResponse.success(responses);
     }

--- a/src/main/java/com/example/i_commerce/domain/review/controller/SellerReviewController.java
+++ b/src/main/java/com/example/i_commerce/domain/review/controller/SellerReviewController.java
@@ -78,28 +78,6 @@ public class SellerReviewController {
         return ApiResponse.success();
     }
 
-    @Operation(summary = "리뷰 답글 생성", description = "판매자는 특정 리뷰에 답글을 한 번 달 수 있다.")
-    @PostMapping("/{reviewId}/comment")
-    @ResponseStatus(HttpStatus.CREATED)
-    public ApiResponse<Void> createComment(
-        @PathVariable Long reviewId,
-        @AuthenticationPrincipal CustomUserPrincipal principal,
-        @RequestBody @Valid CreateCommentRequest request) {
-        reviewCommentService.createComment(reviewId, principal.getId(), request);
-        return ApiResponse.success();
-    }
-
-    @Operation(summary = "리뷰 답글 수정", description = "판매자는 자신이 단 답글을 수정할 수 있다.")
-    @PatchMapping("/comments/{commentId}")
-    public ApiResponse<Long> editComment(
-        @PathVariable Long commentId,
-        @AuthenticationPrincipal CustomUserPrincipal principal,
-        @RequestBody @Valid UpdateCommentRequest request
-    ) {
-        Long editedCommentId = reviewCommentService.editComment(commentId, principal.getId(), request);
-        return ApiResponse.success(editedCommentId);
-    }
-
     @Operation(summary = "판매자 상점 리뷰 목록 조회", description = "판매자가 운영하는 상점에 등록된 모든 상품 리뷰를 페이징하여 조회한다.")
     @GetMapping
     public ApiResponse<SliceResponse<ReviewListResponse>> getSellerReviews(

--- a/src/main/java/com/example/i_commerce/domain/review/entity/Review.java
+++ b/src/main/java/com/example/i_commerce/domain/review/entity/Review.java
@@ -79,8 +79,8 @@ public class Review extends BaseEntity {
     @Builder.Default
     private Long version = 0L;
 
-    @OneToOne(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
-    private ReviewComment comment;
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReviewComment> comments = new ArrayList<>();
 
     @Builder.Default
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/i_commerce/domain/review/entity/ReviewComment.java
+++ b/src/main/java/com/example/i_commerce/domain/review/entity/ReviewComment.java
@@ -12,8 +12,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,25 +35,41 @@ public class ReviewComment extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "review_id", nullable = false)
     private Review review;
 
-    @Column(nullable = false, length = 50)
-    private Long sellerId;
+    @Column(nullable = false)
+    private Long userId;
 
     @Column(columnDefinition = "TEXT")
     private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private ReviewComment parent;
+
+    @OneToMany(mappedBy = "parent", orphanRemoval = true)
+    private List<ReviewComment> children = new ArrayList<>();
 
     public void update(String newContent) {
         this.content = newContent;
     }
 
-    public static ReviewComment of(Review review, Long sellerId, CreateCommentRequest request) {
+    public static ReviewComment of(Review review, Long userId, CreateCommentRequest request) {
         return ReviewComment.builder()
             .review(review)
-            .sellerId(sellerId)
+            .userId(userId)
             .content(request.getContent())
+            .build();
+    }
+
+    public static ReviewComment ofChild(Review review, Long userId, CreateCommentRequest request, ReviewComment parent) {
+        return ReviewComment.builder()
+            .review(review)
+            .userId(userId)
+            .content(request.getContent())
+            .parent(parent)
             .build();
     }
 }

--- a/src/main/java/com/example/i_commerce/domain/review/repository/ReviewCommentRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/review/repository/ReviewCommentRepository.java
@@ -1,13 +1,13 @@
 package com.example.i_commerce.domain.review.repository;
 
 import com.example.i_commerce.domain.review.entity.ReviewComment;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReviewCommentRepository extends JpaRepository<ReviewComment, Long> {
 
-    boolean existsByReviewId(Long reviewId);
-
+    List<ReviewComment> findByReviewId(Long reviewId);
 
 }

--- a/src/main/java/com/example/i_commerce/domain/review/service/ReviewCommentService.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/ReviewCommentService.java
@@ -38,38 +38,37 @@ public class ReviewCommentService {
     private final ProductQueryService productQueryService;
 
     @Transactional
-    public void createComment(Long reviewId, Long sellerId, CreateCommentRequest request) {
+    public void createComment(Long reviewId, Long userId, CreateCommentRequest request) {
 
         Review review = reviewRepo.findById(reviewId)
             .orElseThrow(() -> new AppException(ReviewErrorCode.REVIEW_NOT_FOUND));
 
-        Long storeId = productQueryService.getStoreIdByProductId(review.getProductId());
-
-        if (storeId == null) {
-            throw new AppException(ReviewErrorCode.PRODUCT_NOT_FOUND);
-        }
-
-        if (!storeService.isStoreManager(sellerId, storeId)) {
-            throw new AppException(CommonErrorCode.INVALID_PERMISSION);
-        }
-
-        if (reviewCommentRepo.existsByReviewId(reviewId)) {
-            throw new AppException(ReviewErrorCode.ALREADY_COMMENTED);
-        }
-
         reviewForbiddenWordValidator.validateContent(request.getContent());
-        ReviewComment comment = ReviewComment.of(review, sellerId, request);
 
-        reviewCommentRepo.save(comment);
+        if (request.getParentId() == null) {
+            ReviewComment comment = ReviewComment.of(review, userId, request);
+            reviewCommentRepo.save(comment);
+
+        } else {
+            ReviewComment parent = reviewCommentRepo.findById(request.getParentId())
+                .orElseThrow(() -> new AppException(ReviewErrorCode.COMMENT_NOT_FOUND));
+
+            if (!parent.getReview().getId().equals(reviewId)) {
+                throw new AppException(CommonErrorCode.INVALID_PERMISSION);
+            }
+
+            ReviewComment child = ReviewComment.ofChild(review, userId, request, parent);
+            reviewCommentRepo.save(child);
+        }
     }
 
     @Transactional
-    public Long editComment(Long commentId, Long sellerId, UpdateCommentRequest request) {
+    public Long editComment(Long commentId, Long userId, UpdateCommentRequest request) {
 
         ReviewComment comment = reviewCommentRepo.findById(commentId)
             .orElseThrow(() -> new AppException(ReviewErrorCode.COMMENT_NOT_FOUND));
 
-        if (!comment.getSellerId().equals(sellerId)) {
+        if (!comment.getUserId().equals(userId)) {
             throw new AppException(CommonErrorCode.INVALID_PERMISSION);
         }
 

--- a/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
@@ -256,6 +256,10 @@ public class ReviewService {
     public List<ReviewListResponse> getBestReviewCandidates(Long productId, Long sellerId) {
         Long storeId = productQueryService.getStoreIdByProductId(productId);
 
+        if (storeId == null) {
+            throw new AppException(ReviewErrorCode.PRODUCT_NOT_FOUND);
+        }
+
         if (!storeService.isStoreManager(sellerId, storeId)) {
             throw new AppException(CommonErrorCode.INVALID_PERMISSION);
         }

--- a/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/ReviewService.java
@@ -1,14 +1,19 @@
 package com.example.i_commerce.domain.review.service;
 
+import com.example.i_commerce.domain.member.service.store.StoreService;
 import com.example.i_commerce.domain.order.entity.OrderProduct;
 import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
 import com.example.i_commerce.domain.order.service.OrderService;
 import com.example.i_commerce.domain.order.service.dto.OrderProductResponse;
+import com.example.i_commerce.domain.product.application.service.ProductQueryService;
 import com.example.i_commerce.domain.review.entity.Review;
+import com.example.i_commerce.domain.review.entity.ReviewComment;
 import com.example.i_commerce.domain.review.entity.ReviewImage;
 import com.example.i_commerce.domain.review.exception.ReviewErrorCode;
+import com.example.i_commerce.domain.review.repository.ReviewCommentRepository;
 import com.example.i_commerce.domain.review.repository.ReviewRepository;
 import com.example.i_commerce.domain.review.repository.StarRateCountProjection;
+import com.example.i_commerce.domain.review.service.dto.CommentResponse;
 import com.example.i_commerce.domain.review.service.dto.CreateReviewRequest;
 import com.example.i_commerce.domain.review.service.dto.ReviewResponse;
 import com.example.i_commerce.domain.review.service.dto.ReviewStatsResponse;
@@ -21,7 +26,9 @@ import com.example.i_commerce.global.exception.AppException;
 import com.example.i_commerce.global.exception.common.CommonErrorCode;
 import com.example.i_commerce.global.s3.service.S3ImageService;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -39,6 +46,9 @@ public class ReviewService {
     private final ReviewForbiddenWordValidator reviewForbiddenWordValidator;
     private final S3ImageService s3ImageService;
     private final OrderService orderService;
+    private final StoreService storeService;
+    private final ProductQueryService productQueryService;
+    private final ReviewCommentRepository reviewCommentRepo;
 
     @Transactional
     public Long createReview(Long orderProductId, Long userId, CreateReviewRequest dto, List<MultipartFile> imageFiles) {
@@ -146,10 +156,36 @@ public class ReviewService {
 
         Review review = getReviewOrThrow(reviewId);
 
-        ReviewResponse dto = ReviewResponse.from(review);
+        List<ReviewComment> comments = reviewCommentRepo.findByReviewId(reviewId);
 
-        return dto;
+        List<CommentResponse> commentTree = assembleCommentTree(comments);
+
+        return ReviewResponse.of(review, commentTree);
     }
+    private List<CommentResponse> assembleCommentTree(List<ReviewComment> comments) {
+        Map<Long, CommentResponse> map = new HashMap<>();
+        List<CommentResponse> roots = new ArrayList<>();
+
+        for (ReviewComment c : comments) {
+            map.put(c.getId(), CommentResponse.from(c));
+        }
+
+        for (ReviewComment c : comments) {
+            CommentResponse dto = map.get(c.getId());
+
+            if (c.getParent() == null) {
+                roots.add(dto);
+            } else {
+                CommentResponse parentDto = map.get(c.getParent().getId());
+                if (parentDto != null) {
+                    parentDto.getChildren().add(dto);
+                }
+            }
+        }
+
+        return roots;
+    }
+
 
     @Transactional
     public Long editReview(Long reviewId, Long userId, UpdateReviewRequest dto, List<MultipartFile> newImageFiles) {
@@ -217,8 +253,15 @@ public class ReviewService {
     }
 
     @Transactional
-    public List<ReviewListResponse> getBestReviewCandidates(Long productId) {
+    public List<ReviewListResponse> getBestReviewCandidates(Long productId, Long sellerId) {
+        Long storeId = productQueryService.getStoreIdByProductId(productId);
+
+        if (!storeService.isStoreManager(sellerId, storeId)) {
+            throw new AppException(CommonErrorCode.INVALID_PERMISSION);
+        }
+
         List<Review> reviews = reviewRepo.findAllByProductIdAndDeletedAtIsNull(productId);
+
         reviews.removeIf(Review::isExcluded);
 
         reviews.sort((r1, r2) -> Double.compare(r2.calculateRecommendationScore(),

--- a/src/main/java/com/example/i_commerce/domain/review/service/dto/CommentResponse.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/dto/CommentResponse.java
@@ -30,7 +30,7 @@ public class CommentResponse {
             .userId(comment.getUserId())
             .content(comment.getContent())
             .createdAt(comment.getCreatedAt())
-            .isUpdated(comment.getUpdatedAt() != null && !comment.getCreatedAt().equals(comment.getUpdatedAt()))
+            .isUpdated(comment.getUpdatedAt() != null && !comment.getUpdatedAt().equals(comment.getCreatedAt()))
             .build();
     }
 }

--- a/src/main/java/com/example/i_commerce/domain/review/service/dto/CommentResponse.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/dto/CommentResponse.java
@@ -1,0 +1,36 @@
+package com.example.i_commerce.domain.review.service.dto;
+
+import com.example.i_commerce.domain.review.entity.ReviewComment;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Schema(name = "CommentResponse", description = "리뷰 답글 응답")
+@Getter
+@AllArgsConstructor
+@Builder
+public class CommentResponse {
+
+    private Long commentId;
+    private Long userId;
+    private String content;
+    private LocalDateTime createdAt;
+    private boolean isUpdated;
+
+    @Builder.Default
+    private List<CommentResponse> children = new ArrayList<>();
+
+    public static CommentResponse from(ReviewComment comment) {
+        return CommentResponse.builder()
+            .commentId(comment.getId())
+            .userId(comment.getUserId())
+            .content(comment.getContent())
+            .createdAt(comment.getCreatedAt())
+            .isUpdated(comment.getUpdatedAt() != null && !comment.getCreatedAt().equals(comment.getUpdatedAt()))
+            .build();
+    }
+}

--- a/src/main/java/com/example/i_commerce/domain/review/service/dto/CreateCommentRequest.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/dto/CreateCommentRequest.java
@@ -13,4 +13,6 @@ public class CreateCommentRequest {
 
     private String content;
 
+    private Long parentId;
+
 }

--- a/src/main/java/com/example/i_commerce/domain/review/service/dto/ReviewResponse.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/dto/ReviewResponse.java
@@ -16,6 +16,8 @@ import lombok.Getter;
 @Builder
 public class ReviewResponse {
 
+    private Long reviewId;
+
     private Long userId;
 
     private String content;

--- a/src/main/java/com/example/i_commerce/domain/review/service/dto/ReviewResponse.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/dto/ReviewResponse.java
@@ -32,7 +32,31 @@ public class ReviewResponse {
 
     private boolean isUpdated;
 
+    private List<CommentResponse> comments;
+
     public static ReviewResponse from(Review review) {
+
+        List<String> extractedUrls = review.getImages() != null ?
+            review.getImages().stream()
+                .map(ReviewImage::getImageUrl)
+                .toList()
+            : Collections.emptyList();
+
+        return ReviewResponse.builder()
+            .reviewId(review.getId())
+            .userId(review.getUserId())
+            .content(review.getContent())
+            .starRate(review.getStarRate())
+            .imageUrls(extractedUrls)
+            .isBest(Boolean.TRUE.equals(review.getIsBest()))
+            .likeCount(review.getLikeCount())
+            .createdAt(review.getCreatedAt())
+            .isUpdated(Boolean.TRUE.equals(review.getIsUpdated()))
+            .comments(Collections.emptyList())
+            .build();
+    }
+
+    public static ReviewResponse of(Review review, List<CommentResponse> comments) {
 
         List<String> extractedUrls = review.getImages() != null ?
             review.getImages().stream()
@@ -49,6 +73,7 @@ public class ReviewResponse {
             .likeCount(review.getLikeCount())
             .createdAt(review.getCreatedAt())
             .isUpdated(Boolean.TRUE.equals(review.getIsUpdated()))
+            .comments(comments)
             .build();
     }
 

--- a/src/main/java/com/example/i_commerce/domain/review/service/dto/ReviewResponse.java
+++ b/src/main/java/com/example/i_commerce/domain/review/service/dto/ReviewResponse.java
@@ -67,6 +67,7 @@ public class ReviewResponse {
             : Collections.emptyList();
 
         return ReviewResponse.builder()
+            .reviewId(review.getId())
             .userId(review.getUserId())
             .content(review.getContent())
             .starRate(review.getStarRate())


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
closed 158

## ✏️ Work Description
- 기존 판매자 전용 답글을 일반 로그인 유저라면 답글을 작성할 수 있는 무한 뎁스로 소통할 수 있는 개방형 구조로 확장
- 무한 뎁스 조회 시 발생하는 N+1 쿼리 문제를 방지하기 위해, 전체 댓글을 1차원 리스트로 일괄 조회 후 자바 메모리(Map)단에서 O(N)으로 트리 구조를 조립하는 알고리즘 구현
- `Review` 엔티티의 매핑을 `@OneToOne`에서 `@OneToMany`로 변경
- 답글 API를 일반 리뷰 컨트롤러로 옮기고 댓글 수정 시 작성자 본인 여부를 검증하는 로직 적용

## 📢 To Reviewers
- 테스트 코드 pr도 빨리 올리겠습니다.

