### PR TITLE
Feature/170 order delivery api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,6 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
   influxdb:
     image: influxdb:1.8
-    container_name: local-influxdb
     ports:
       - "8086:8086"
     volumes:

--- a/k6/domains/order/seller-delivery-controller.js
+++ b/k6/domains/order/seller-delivery-controller.js
@@ -14,7 +14,7 @@ export function getHeaders(authToken) {
 export function getDeliveryList(authToken, storeId, trackingNumber) {
     const url = `${BASE_URL}/api/v1/deliveries/${storeId}?status=preparing`;
 
-    return http.patch(url, getHeaders(authToken));
+    return http.get(url, getHeaders(authToken));
 }
 
 export function updateDeliveryStatus(authToken, deliverId, trackingNumber) {

--- a/k6/domains/order/seller-delivery-controller.js
+++ b/k6/domains/order/seller-delivery-controller.js
@@ -11,6 +11,12 @@ export function getHeaders(authToken) {
   };
 }
 
+export function getDeliveryList(authToken, storeId, trackingNumber) {
+    const url = `${BASE_URL}/api/v1/deliveries/${storeId}?status=preparing`;
+
+    return http.patch(url, getHeaders(authToken));
+}
+
 export function updateDeliveryStatus(authToken, deliverId, trackingNumber) {
     const url = `${BASE_URL}/api/v1/deliveries/ship`;
 

--- a/src/main/java/com/example/i_commerce/ICommerceApplication.java
+++ b/src/main/java/com/example/i_commerce/ICommerceApplication.java
@@ -7,12 +7,14 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableConfigurationProperties(BootstrapAdminProperties.class)//최초관리자
 @EnableJpaAuditing //엔티티 객체 생성, 수정일자 관리
 @EnableScheduling
 @EnableCaching //스프링 캐시 기능 활성화
+@EnableAsync
 @SpringBootApplication
 public class ICommerceApplication {
 

--- a/src/main/java/com/example/i_commerce/domain/order/config/WebConfig.java
+++ b/src/main/java/com/example/i_commerce/domain/order/config/WebConfig.java
@@ -1,0 +1,15 @@
+package com.example.i_commerce.domain.order.config;
+
+import org.jspecify.annotations.NonNull;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.boot.convert.ApplicationConversionService;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addFormatters(@NonNull FormatterRegistry registry) {
+        ApplicationConversionService.configure(registry);
+    }
+}

--- a/src/main/java/com/example/i_commerce/domain/order/controller/SellerDeliveryController.java
+++ b/src/main/java/com/example/i_commerce/domain/order/controller/SellerDeliveryController.java
@@ -47,6 +47,3 @@ public class SellerDeliveryController {
         return sellerDeliveryService.shipDelivery(seller.getId(), request);
     }
 }
-
-// 할거
-// 배송 서비스 가짜 서버 만드는거 고려해보기

--- a/src/main/java/com/example/i_commerce/domain/order/controller/SellerDeliveryController.java
+++ b/src/main/java/com/example/i_commerce/domain/order/controller/SellerDeliveryController.java
@@ -1,13 +1,25 @@
 package com.example.i_commerce.domain.order.controller;
 
+import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
 import com.example.i_commerce.domain.order.service.SellerDeliveryService;
+import com.example.i_commerce.domain.order.service.dto.DeliveryResponse;
 import com.example.i_commerce.domain.order.service.dto.DeliveryShipRequest;
 import com.example.i_commerce.global.common.response.ApiResponse;
+import com.example.i_commerce.global.security.principal.CustomUserPrincipal;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,10 +29,24 @@ public class SellerDeliveryController {
 
     private final SellerDeliveryService sellerDeliveryService;
 
+    @GetMapping("/{storeId}")
+    @PreAuthorize("hasRole('SELLER')")
+    public ApiResponse<Page<DeliveryResponse>> getDeliveries(
+            @AuthenticationPrincipal CustomUserPrincipal seller,
+            @PathVariable Long storeId,
+            @RequestParam(required = false) DeliveryStatus status,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return sellerDeliveryService.getDeliveryList(seller.getId(), storeId, status, pageable);
+    }
+
     @PatchMapping("/ship")
     @PreAuthorize("hasRole('SELLER')")
-    public ApiResponse<Void> shipProduct(@RequestBody DeliveryShipRequest request) {
-        sellerDeliveryService.shipDelivery(request);
-        return ApiResponse.success();
+    public ApiResponse<Void> shipProduct(
+            @AuthenticationPrincipal CustomUserPrincipal seller,
+            @RequestBody DeliveryShipRequest request) {
+        return sellerDeliveryService.shipDelivery(seller.getId(), request);
     }
 }
+
+// 할거
+// 배송 서비스 가짜 서버 만드는거 고려해보기

--- a/src/main/java/com/example/i_commerce/domain/order/controller/SellerDeliveryController.java
+++ b/src/main/java/com/example/i_commerce/domain/order/controller/SellerDeliveryController.java
@@ -35,7 +35,7 @@ public class SellerDeliveryController {
             @AuthenticationPrincipal CustomUserPrincipal seller,
             @PathVariable Long storeId,
             @RequestParam(required = false) DeliveryStatus status,
-            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable) {
         return sellerDeliveryService.getDeliveryList(seller.getId(), storeId, status, pageable);
     }
 

--- a/src/main/java/com/example/i_commerce/domain/order/entity/Delivery.java
+++ b/src/main/java/com/example/i_commerce/domain/order/entity/Delivery.java
@@ -2,7 +2,9 @@ package com.example.i_commerce.domain.order.entity;
 
 import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
 import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
+import com.example.i_commerce.domain.order.exception.DeliveryErrorCode;
 import com.example.i_commerce.global.common.entity.BaseEntity;
+import com.example.i_commerce.global.exception.AppException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -56,6 +58,9 @@ public class Delivery extends BaseEntity {
     }
 
     public void registerTrackingNumber(String trackingNo) {
+        if (this.deliveryStatus != DeliveryStatus.PREPARING) {
+            throw new AppException(DeliveryErrorCode.CANNOT_SHIP_STATUS);
+        }
         this.trackingNo = trackingNo;
         this.changeDeliveryStatus(DeliveryStatus.SHIPPING);
     }

--- a/src/main/java/com/example/i_commerce/domain/order/entity/emuns/OrderStatus.java
+++ b/src/main/java/com/example/i_commerce/domain/order/entity/emuns/OrderStatus.java
@@ -8,8 +8,10 @@ import lombok.Getter;
 public enum OrderStatus {
     PENDING("주문 대기", "주문서가 생성되고 결제 대기 상태입니다."),
     CONFIRMED("주문 접수", "결제가 완료되어 배송을 준비 중입니다."),
-    SHIPPING("배송 중", "상품이 배송 중입니다.(하나라도 출발 시)"),
+    SHIPPING("배송 중", "주문한 모든 상품이 배송 중입니다."),
     DELIVERED("배송 완료", "모든 상품이 배송지에 도착했습니다."),
+    PARTIAL_SHIPPING("일부 배송 중", "일부는 준비 중, 일부는 배송을 시작했습니다."),
+    PARTIAL_DELIVERED("일부 배송 완료", "일부는 배송 완료, 일부는 여전히 배송 중입니다."),
     COMPLETED("구매 확정", ""),
     CANCELLED("주문 취소", ""),
     UNKNOWN_HOLD("결제 성공을 알 수 없는 상태", "결제가 성공/실패 했는지 파악할 수 없습니다."),

--- a/src/main/java/com/example/i_commerce/domain/order/event/dto/DeliveryStatusChangedEvent.java
+++ b/src/main/java/com/example/i_commerce/domain/order/event/dto/DeliveryStatusChangedEvent.java
@@ -1,0 +1,6 @@
+package com.example.i_commerce.domain.order.event.dto;
+
+public record DeliveryStatusChangedEvent(
+        Long orderId
+) {
+}

--- a/src/main/java/com/example/i_commerce/domain/order/event/dto/DeliveryStatusChangedEvent.java
+++ b/src/main/java/com/example/i_commerce/domain/order/event/dto/DeliveryStatusChangedEvent.java
@@ -1,6 +1,10 @@
 package com.example.i_commerce.domain.order.event.dto;
 
+import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
+
 public record DeliveryStatusChangedEvent(
-        Long orderId
+        Long orderId,
+        Long deliveryId,
+        DeliveryStatus currentStatus
 ) {
 }

--- a/src/main/java/com/example/i_commerce/domain/order/event/dto/PaymentStatusChangedEvent.java
+++ b/src/main/java/com/example/i_commerce/domain/order/event/dto/PaymentStatusChangedEvent.java
@@ -4,13 +4,11 @@ import com.example.i_commerce.domain.order.entity.Payment;
 import com.example.i_commerce.domain.order.entity.emuns.PaymentStatus;
 
 public record PaymentStatusChangedEvent(
-        Payment payment,
+        Long paymentId,
         PaymentStatus previousStatus,
         String reason,
         PaymentStatus currentStatus,
         String pgTid,
         String rawData
 ) {
-
-
 }

--- a/src/main/java/com/example/i_commerce/domain/order/event/listener/OrderListener.java
+++ b/src/main/java/com/example/i_commerce/domain/order/event/listener/OrderListener.java
@@ -1,0 +1,24 @@
+package com.example.i_commerce.domain.order.event.listener;
+
+import com.example.i_commerce.domain.order.event.dto.DeliveryStatusChangedEvent;
+import com.example.i_commerce.domain.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class OrderListener {
+
+    private final OrderService orderService;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleDeliveryStatusChanged(DeliveryStatusChangedEvent event) {
+        orderService.updateOrderStatusByDeliveries(event.orderId());
+    }
+
+}

--- a/src/main/java/com/example/i_commerce/domain/order/event/listener/PaymentLogListener.java
+++ b/src/main/java/com/example/i_commerce/domain/order/event/listener/PaymentLogListener.java
@@ -5,6 +5,8 @@ import com.example.i_commerce.domain.order.service.PaymentHistoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -15,6 +17,7 @@ public class PaymentLogListener {
 
     private final PaymentHistoryService paymentHistoryService;
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void createPaymentHistoryRequest(PaymentStatusChangedEvent event) {
         paymentHistoryService.createPaymentHistory(event);

--- a/src/main/java/com/example/i_commerce/domain/order/exception/DeliveryErrorCode.java
+++ b/src/main/java/com/example/i_commerce/domain/order/exception/DeliveryErrorCode.java
@@ -11,6 +11,8 @@ public enum DeliveryErrorCode implements ErrorCode {
 
     CANNOT_SHIP_STATUS(HttpStatus.BAD_REQUEST, "DEV-40001", "배송 준비중(PREPARING) 상태의 상품만 배송 처리할 수 있습니다."),
 
+    STORE_FORBIDDEN(HttpStatus.FORBIDDEN, "DEV-40301", "입력한 정보를 확인해주세요."),
+
     DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "DEV-40401", "배송 정보를 찾을 수 없습니다.")
     ;
 

--- a/src/main/java/com/example/i_commerce/domain/order/exception/DeliveryErrorCode.java
+++ b/src/main/java/com/example/i_commerce/domain/order/exception/DeliveryErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum DeliveryErrorCode implements ErrorCode {
 
     CANNOT_SHIP_STATUS(HttpStatus.BAD_REQUEST, "DEV-40001", "배송 준비중(PREPARING) 상태의 상품만 배송 처리할 수 있습니다."),
+    INVALID_DELIVERY_ORDER(HttpStatus.BAD_REQUEST, "DEV-40002", "해당 배송 정보와 일치하지 않는 주문 번호입니다."),
 
     STORE_FORBIDDEN(HttpStatus.FORBIDDEN, "DEV-40301", "입력한 정보를 확인해주세요."),
 

--- a/src/main/java/com/example/i_commerce/domain/order/repository/DeliveryRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/order/repository/DeliveryRepository.java
@@ -1,9 +1,27 @@
 package com.example.i_commerce.domain.order.repository;
 
 import com.example.i_commerce.domain.order.entity.Delivery;
+import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
+import com.example.i_commerce.domain.product.entity.Option;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     List<Delivery> findAllByOrderId(Long aLong);
+
+    @EntityGraph(attributePaths = {"order"})
+    @Query("select d from Delivery d where d.storeId = :storeId and (:status is null or d.deliveryStatus = :status )")
+    Page<Delivery> findAllByStoreId(
+            @Param("storeId") Long storeId,
+            @Param("status") DeliveryStatus status,
+            Pageable pageable);
+
+    @EntityGraph(attributePaths = {"order"})
+    Optional<Delivery> findBWithOrderById(Long id);
 }

--- a/src/main/java/com/example/i_commerce/domain/order/repository/DeliveryRepository.java
+++ b/src/main/java/com/example/i_commerce/domain/order/repository/DeliveryRepository.java
@@ -2,7 +2,6 @@ package com.example.i_commerce.domain.order.repository;
 
 import com.example.i_commerce.domain.order.entity.Delivery;
 import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
-import com.example.i_commerce.domain.product.entity.Option;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -23,5 +22,5 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
             Pageable pageable);
 
     @EntityGraph(attributePaths = {"order"})
-    Optional<Delivery> findBWithOrderById(Long id);
+    Optional<Delivery> findWithOrderById(Long id);
 }

--- a/src/main/java/com/example/i_commerce/domain/order/service/AutoPaymentCancelService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/AutoPaymentCancelService.java
@@ -42,7 +42,7 @@ public class AutoPaymentCancelService {
             order.changeOrderStatus(OrderStatus.CANCELLED);
 
             publisher.publishEvent(new PaymentStatusChangedEvent(
-                    payment, PaymentStatus.READY, dto.cancelReason(), PaymentStatus.FAILED, dto.paymentKey(), response.toString()));
+                    payment.getId(), PaymentStatus.READY, dto.cancelReason(), PaymentStatus.FAILED, dto.paymentKey(), response.toString()));
         } catch (AppException e) {
             if (e.getErrorCode() == PaymentErrorCode.PAYMENT_NETWORK_TIMEOUT) {
                 log.error("[자동 취소 실패] 자동 취소 시도 중 타임아웃 발생. 토스 장부 확인 불가.");

--- a/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
@@ -5,13 +5,16 @@ import com.example.i_commerce.domain.member.service.delivery.DeliveryAddressServ
 import com.example.i_commerce.domain.member.service.delivery.dto.DeliveryAddressSnapshot;
 import com.example.i_commerce.domain.member.service.member.MemberService;
 import com.example.i_commerce.domain.member.service.member.dto.MemberOrderInfo;
+import com.example.i_commerce.domain.order.entity.Delivery;
 import com.example.i_commerce.domain.order.entity.Order;
 import com.example.i_commerce.domain.order.entity.OrderProduct;
 import com.example.i_commerce.domain.order.entity.Payment;
+import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
 import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
 import com.example.i_commerce.domain.order.entity.emuns.PaymentStatus;
 import com.example.i_commerce.domain.order.exception.OrderErrorCode;
 import com.example.i_commerce.domain.order.exception.PaymentErrorCode;
+import com.example.i_commerce.domain.order.repository.DeliveryRepository;
 import com.example.i_commerce.domain.order.repository.OrderProductRepository;
 import com.example.i_commerce.domain.order.repository.OrderRepository;
 import com.example.i_commerce.domain.order.repository.PaymentRepository;
@@ -49,6 +52,7 @@ public class OrderService {
     private final PaymentRepository paymentRepository;
     private final DeliveryAddressService deliveryAddressService;
     private final OrderProductRepository orderProductRepository;
+    private final DeliveryRepository deliveryRepository;
 
     @Transactional
     public ApiResponse<CreateOrderResponse> createOrder(Long memberId, CreateOrderRequest dto) {
@@ -163,5 +167,31 @@ public class OrderService {
             orderProduct.getOrder().getUserId(),
             orderProduct.getOrder().getOrderStatus()
         );
+    }
+
+    @Transactional
+    public void updateOrderStatusByDeliveries(Long orderId) {
+        Order order = orderRepository.findById(orderId).orElseThrow();
+        List<Delivery> deliveries = deliveryRepository.findAllByOrderId(orderId);
+
+        OrderStatus nextStatus = determineOrderStatus(deliveries);
+
+        order.changeOrderStatus(nextStatus);
+    }
+
+    private OrderStatus determineOrderStatus(List<Delivery> deliveries) {
+        boolean allShipped = deliveries.stream()
+                .allMatch(d -> d.getDeliveryStatus() == DeliveryStatus.SHIPPING);
+
+        boolean anyShipped = deliveries.stream()
+                .anyMatch(d -> d.getDeliveryStatus() == DeliveryStatus.SHIPPING);
+
+        if (allShipped) {
+            return OrderStatus.DELIVERED;
+        } else if (anyShipped) {
+            return OrderStatus.SHIPPING;
+        }
+
+        return OrderStatus.CONFIRMED;
     }
 }

--- a/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
@@ -180,16 +180,27 @@ public class OrderService {
     }
 
     private OrderStatus determineOrderStatus(List<Delivery> deliveries) {
-        boolean allShipped = deliveries.stream()
-                .allMatch(d -> d.getDeliveryStatus() == DeliveryStatus.SHIPPING);
+        long totalCount = deliveries.size();
 
-        boolean anyShipped = deliveries.stream()
-                .anyMatch(d -> d.getDeliveryStatus() == DeliveryStatus.SHIPPING);
+        long shippingCount = deliveries.stream()
+                .filter(d -> d.getDeliveryStatus() == DeliveryStatus.SHIPPING)
+                .count();
 
-        if (allShipped) {
+        long arrivedCount = deliveries.stream()
+                .filter(d -> d.getDeliveryStatus() == DeliveryStatus.ARRIVED)
+                .count();
+
+        if (arrivedCount == totalCount) {
             return OrderStatus.DELIVERED;
-        } else if (anyShipped) {
+        }
+        if (shippingCount == totalCount) {
             return OrderStatus.SHIPPING;
+        }
+        if (arrivedCount > 0) {
+            return OrderStatus.PARTIAL_DELIVERED;
+        }
+        if (shippingCount > 0) {
+            return OrderStatus.PARTIAL_SHIPPING;
         }
 
         return OrderStatus.CONFIRMED;

--- a/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
@@ -171,7 +171,7 @@ public class OrderService {
 
     @Transactional
     public void updateOrderStatusByDeliveries(Long orderId) {
-        Order order = orderRepository.findById(orderId).orElseThrow();
+        Order order = orderRepository.findById(orderId).orElseThrow(() -> new AppException(OrderErrorCode.ORDER_NOT_FOUND));
         List<Delivery> deliveries = deliveryRepository.findAllByOrderId(orderId);
 
         OrderStatus nextStatus = determineOrderStatus(deliveries);

--- a/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
@@ -183,16 +183,27 @@ public class OrderService {
     }
 
     private OrderStatus determineOrderStatus(List<Delivery> deliveries) {
-        boolean allShipped = deliveries.stream()
-                .allMatch(d -> d.getDeliveryStatus() == DeliveryStatus.SHIPPING);
+        long totalCount = deliveries.size();
 
-        boolean anyShipped = deliveries.stream()
-                .anyMatch(d -> d.getDeliveryStatus() == DeliveryStatus.SHIPPING);
+        long shippingCount = deliveries.stream()
+                .filter(d -> d.getDeliveryStatus() == DeliveryStatus.SHIPPING)
+                .count();
 
-        if (allShipped) {
+        long arrivedCount = deliveries.stream()
+                .filter(d -> d.getDeliveryStatus() == DeliveryStatus.ARRIVED)
+                .count();
+
+        if (arrivedCount == totalCount) {
             return OrderStatus.DELIVERED;
-        } else if (anyShipped) {
+        }
+        if (shippingCount == totalCount) {
             return OrderStatus.SHIPPING;
+        }
+        if (arrivedCount > 0) {
+            return OrderStatus.PARTIAL_DELIVERED;
+        }
+        if (shippingCount > 0) {
+            return OrderStatus.PARTIAL_SHIPPING;
         }
 
         return OrderStatus.CONFIRMED;

--- a/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/OrderService.java
@@ -5,13 +5,16 @@ import com.example.i_commerce.domain.member.service.delivery.DeliveryAddressServ
 import com.example.i_commerce.domain.member.service.delivery.dto.DeliveryAddressSnapshot;
 import com.example.i_commerce.domain.member.service.member.MemberService;
 import com.example.i_commerce.domain.member.service.member.dto.MemberOrderInfo;
+import com.example.i_commerce.domain.order.entity.Delivery;
 import com.example.i_commerce.domain.order.entity.Order;
 import com.example.i_commerce.domain.order.entity.OrderProduct;
 import com.example.i_commerce.domain.order.entity.Payment;
+import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
 import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
 import com.example.i_commerce.domain.order.entity.emuns.PaymentStatus;
 import com.example.i_commerce.domain.order.exception.OrderErrorCode;
 import com.example.i_commerce.domain.order.exception.PaymentErrorCode;
+import com.example.i_commerce.domain.order.repository.DeliveryRepository;
 import com.example.i_commerce.domain.order.repository.OrderProductRepository;
 import com.example.i_commerce.domain.order.repository.OrderRepository;
 import com.example.i_commerce.domain.order.repository.PaymentRepository;
@@ -52,6 +55,7 @@ public class OrderService {
     private final PaymentRepository paymentRepository;
     private final DeliveryAddressService deliveryAddressService;
     private final OrderProductRepository orderProductRepository;
+    private final DeliveryRepository deliveryRepository;
 
     @Transactional
     public ApiResponse<CreateOrderResponse> createOrder(Long memberId, CreateOrderRequest dto) {
@@ -166,5 +170,31 @@ public class OrderService {
             orderProduct.getOrder().getUserId(),
             orderProduct.getOrder().getOrderStatus()
         );
+    }
+
+    @Transactional
+    public void updateOrderStatusByDeliveries(Long orderId) {
+        Order order = orderRepository.findById(orderId).orElseThrow();
+        List<Delivery> deliveries = deliveryRepository.findAllByOrderId(orderId);
+
+        OrderStatus nextStatus = determineOrderStatus(deliveries);
+
+        order.changeOrderStatus(nextStatus);
+    }
+
+    private OrderStatus determineOrderStatus(List<Delivery> deliveries) {
+        boolean allShipped = deliveries.stream()
+                .allMatch(d -> d.getDeliveryStatus() == DeliveryStatus.SHIPPING);
+
+        boolean anyShipped = deliveries.stream()
+                .anyMatch(d -> d.getDeliveryStatus() == DeliveryStatus.SHIPPING);
+
+        if (allShipped) {
+            return OrderStatus.DELIVERED;
+        } else if (anyShipped) {
+            return OrderStatus.SHIPPING;
+        }
+
+        return OrderStatus.CONFIRMED;
     }
 }

--- a/src/main/java/com/example/i_commerce/domain/order/service/PaymentHistoryService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/PaymentHistoryService.java
@@ -4,7 +4,10 @@ import com.example.i_commerce.domain.order.entity.Order;
 import com.example.i_commerce.domain.order.entity.Payment;
 import com.example.i_commerce.domain.order.entity.PaymentHistory;
 import com.example.i_commerce.domain.order.event.dto.PaymentStatusChangedEvent;
+import com.example.i_commerce.domain.order.exception.PaymentErrorCode;
 import com.example.i_commerce.domain.order.repository.PaymentHistoryRepository;
+import com.example.i_commerce.domain.order.repository.PaymentRepository;
+import com.example.i_commerce.global.exception.AppException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -14,11 +17,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PaymentHistoryService {
 
+    private final PaymentRepository paymentRepository;
     private final PaymentHistoryRepository paymentHistoryRepository;
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void createPaymentHistory(PaymentStatusChangedEvent event) {
-        Payment payment = event.payment();
+        Payment payment = paymentRepository.findById(event.paymentId()).orElseThrow(() -> new AppException(
+                PaymentErrorCode.PAYMENT_NOT_FOUND));
+
         Order order = payment.getOrder();
         paymentHistoryRepository.save(
                 PaymentHistory.builder()
@@ -32,8 +38,6 @@ public class PaymentHistoryService {
                         .actorId(order.getUserId())
                         .build()
         );
-
-
     }
 
 }

--- a/src/main/java/com/example/i_commerce/domain/order/service/PaymentService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/PaymentService.java
@@ -121,7 +121,7 @@ public class PaymentService {
 
         publisher.publishEvent(new PaymentApprovedEvent(payment.getOrder().getId()));
         publisher.publishEvent(
-            new PaymentStatusChangedEvent(payment, previousStatus, "결제 완료", PaymentStatus.PAID,
+            new PaymentStatusChangedEvent(payment.getId(), previousStatus, "결제 완료", PaymentStatus.PAID,
                 pgTid, responseStr));
     }
 
@@ -130,7 +130,7 @@ public class PaymentService {
         String responseStr) {
         Payment payment = paymentRepository.findById(paymentId).orElseThrow();
         publisher.publishEvent(
-            new PaymentStatusChangedEvent(payment, previousStatus, "재고 부족으로 인한 자동 취소",
+            new PaymentStatusChangedEvent(payment.getId(), previousStatus, "재고 부족으로 인한 자동 취소",
                 PaymentStatus.FAILED, pgTid, responseStr));
     }
 
@@ -204,7 +204,7 @@ public class PaymentService {
             .forEach(delivery -> delivery.changeDeliveryStatus(DeliveryStatus.CANCELLED));
 
         publisher.publishEvent(new PaymentStatusChangedEvent(
-            payment, previousStatus, dto.cancelReason(),
+            payment.getId(), previousStatus, dto.cancelReason(),
             PaymentStatus.CANCELLED, pgTid, responseStr));
     }
 

--- a/src/main/java/com/example/i_commerce/domain/order/service/SellerDeliveryService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/SellerDeliveryService.java
@@ -35,11 +35,11 @@ public class SellerDeliveryService {
             throw new AppException(DeliveryErrorCode.STORE_FORBIDDEN);
         }
 
-        Delivery delivery = deliveryRepository.findBWithOrderById(request.deliveryId())
+        Delivery delivery = deliveryRepository.findWithOrderById(request.deliveryId())
                 .orElseThrow(() -> new AppException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
 
         if (!request.orderId().equals(delivery.getOrder().getId())) {
-            throw new AppException(DeliveryErrorCode.CANNOT_SHIP_STATUS);
+            throw new AppException(DeliveryErrorCode.INVALID_DELIVERY_ORDER);
         }
 
         delivery.registerTrackingNumber(request.trackingNumber());
@@ -53,7 +53,7 @@ public class SellerDeliveryService {
         Store store = storeRepository.findById(storeId).orElseThrow();
 
         if(!Objects.equals(store.getSellerId(), sellerId)) {
-            throw new AppException(DeliveryErrorCode.DELIVERY_NOT_FOUND);
+            throw new AppException(DeliveryErrorCode.STORE_FORBIDDEN);
         }
 
         Page<Delivery> deliveryPage = deliveryRepository.findAllByStoreId(storeId, status, pageable);
@@ -65,7 +65,7 @@ public class SellerDeliveryService {
     @Transactional
     public void completeDelivery(Long orderId, Long deliveryId) {
 
-        Delivery delivery = deliveryRepository.findBWithOrderById(deliveryId).orElseThrow(() ->
+        Delivery delivery = deliveryRepository.findWithOrderById(deliveryId).orElseThrow(() ->
                 new AppException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
 
         if(!Objects.equals(delivery.getOrder().getId(), orderId)) {

--- a/src/main/java/com/example/i_commerce/domain/order/service/SellerDeliveryService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/SellerDeliveryService.java
@@ -43,8 +43,7 @@ public class SellerDeliveryService {
         }
 
         delivery.registerTrackingNumber(request.trackingNumber());
-
-        publisher.publishEvent(new DeliveryStatusChangedEvent(delivery.getOrder().getId()));
+        publisher.publishEvent(new DeliveryStatusChangedEvent(delivery.getOrder().getId(), delivery.getId(), delivery.getDeliveryStatus()));
         return ApiResponse.success();
     }
 
@@ -61,5 +60,20 @@ public class SellerDeliveryService {
         return ApiResponse.success(deliveryPage.map(delivery ->
             DeliveryResponse.of(delivery.getOrder().getId(), delivery)
         ));
+    }
+
+    @Transactional
+    public void completeDelivery(Long orderId, Long deliveryId) {
+
+        Delivery delivery = deliveryRepository.findBWithOrderById(deliveryId).orElseThrow(() ->
+                new AppException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
+
+        if(!Objects.equals(delivery.getOrder().getId(), orderId)) {
+            throw new AppException(DeliveryErrorCode.INVALID_DELIVERY_ORDER);
+        }
+
+        delivery.changeDeliveryStatus(DeliveryStatus.ARRIVED);
+
+        publisher.publishEvent(new DeliveryStatusChangedEvent(orderId, deliveryId, DeliveryStatus.ARRIVED));
     }
 }

--- a/src/main/java/com/example/i_commerce/domain/order/service/SellerDeliveryService.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/SellerDeliveryService.java
@@ -1,12 +1,21 @@
 package com.example.i_commerce.domain.order.service;
 
+import com.example.i_commerce.domain.member.entity.Store;
+import com.example.i_commerce.domain.member.repository.StoreRepository;
 import com.example.i_commerce.domain.order.entity.Delivery;
 import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
+import com.example.i_commerce.domain.order.event.dto.DeliveryStatusChangedEvent;
 import com.example.i_commerce.domain.order.exception.DeliveryErrorCode;
 import com.example.i_commerce.domain.order.repository.DeliveryRepository;
+import com.example.i_commerce.domain.order.service.dto.DeliveryResponse;
 import com.example.i_commerce.domain.order.service.dto.DeliveryShipRequest;
+import com.example.i_commerce.global.common.response.ApiResponse;
 import com.example.i_commerce.global.exception.AppException;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,16 +23,43 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SellerDeliveryService {
     private final DeliveryRepository deliveryRepository;
+    private final StoreRepository storeRepository;
+    private final ApplicationEventPublisher publisher;
 
     @Transactional
-    public void shipDelivery(DeliveryShipRequest request) {
-        Delivery delivery = deliveryRepository.findById(request.deliveryId())
+    public ApiResponse<Void> shipDelivery(Long sellerId, DeliveryShipRequest request) {
+
+        Store store = storeRepository.findById(request.storeId()).orElseThrow();
+
+        if(!Objects.equals(store.getSellerId(), sellerId)) {
+            throw new AppException(DeliveryErrorCode.STORE_FORBIDDEN);
+        }
+
+        Delivery delivery = deliveryRepository.findBWithOrderById(request.deliveryId())
                 .orElseThrow(() -> new AppException(DeliveryErrorCode.DELIVERY_NOT_FOUND));
 
-        if (delivery.getDeliveryStatus() != DeliveryStatus.PREPARING) {
+        if (!request.orderId().equals(delivery.getOrder().getId())) {
             throw new AppException(DeliveryErrorCode.CANNOT_SHIP_STATUS);
         }
 
         delivery.registerTrackingNumber(request.trackingNumber());
+
+        publisher.publishEvent(new DeliveryStatusChangedEvent(delivery.getOrder().getId()));
+        return ApiResponse.success();
+    }
+
+    @Transactional(readOnly = true)
+    public ApiResponse<Page<DeliveryResponse>> getDeliveryList(Long sellerId, Long storeId, DeliveryStatus status, Pageable pageable) {
+
+        Store store = storeRepository.findById(storeId).orElseThrow();
+
+        if(!Objects.equals(store.getSellerId(), sellerId)) {
+            throw new AppException(DeliveryErrorCode.DELIVERY_NOT_FOUND);
+        }
+
+        Page<Delivery> deliveryPage = deliveryRepository.findAllByStoreId(storeId, status, pageable);
+        return ApiResponse.success(deliveryPage.map(delivery ->
+            DeliveryResponse.of(delivery.getOrder().getId(), delivery)
+        ));
     }
 }

--- a/src/main/java/com/example/i_commerce/domain/order/service/dto/DeliveryResponse.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/dto/DeliveryResponse.java
@@ -1,0 +1,24 @@
+package com.example.i_commerce.domain.order.service.dto;
+
+import com.example.i_commerce.domain.order.entity.Delivery;
+import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
+import java.time.LocalDateTime;
+
+public record DeliveryResponse(
+        Long orderId,
+        Long deliveryId,
+        Long storeId,
+        DeliveryStatus status,
+        LocalDateTime createdAt
+) {
+
+    public static DeliveryResponse of(Long orderId, Delivery delivery) {
+        return new DeliveryResponse (
+                orderId,
+                delivery.getId(),
+                delivery.getStoreId(),
+                delivery.getDeliveryStatus(),
+                delivery.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/i_commerce/domain/order/service/dto/DeliveryShipRequest.java
+++ b/src/main/java/com/example/i_commerce/domain/order/service/dto/DeliveryShipRequest.java
@@ -4,6 +4,10 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record DeliveryShipRequest(
+        @NotNull(message = "주문 ID는 필수입니다.")
+        Long orderId,
+        @NotNull(message = "상점 ID는 필수입니다.")
+        Long storeId,
         @NotNull(message = "배송 ID는 필수입니다.")
         Long deliveryId,
         @NotBlank(message = "송장 번호는 필수입니다.")

--- a/src/main/java/com/example/i_commerce/domain/order/support/MockCourierComponent.java
+++ b/src/main/java/com/example/i_commerce/domain/order/support/MockCourierComponent.java
@@ -6,6 +6,7 @@ import com.example.i_commerce.domain.order.service.SellerDeliveryService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 @Profile("k6")
@@ -42,7 +44,7 @@ public class MockCourierComponent {
             try {
                 Thread.sleep(3000);
 
-                System.out.println("====== [가상 택배사] 배송 ID " + deliveryId + " 배송 완료 처리 진행 ======");
+                log.info("====== [가상 택배사] 배송 ID {} 배송 완료 처리 진행 ======", deliveryId);
                  sellerDeliveryService.completeDelivery(orderId, deliveryId);
 
             } catch (InterruptedException e) {

--- a/src/main/java/com/example/i_commerce/domain/order/support/MockCourierComponent.java
+++ b/src/main/java/com/example/i_commerce/domain/order/support/MockCourierComponent.java
@@ -42,7 +42,8 @@ public class MockCourierComponent {
         Long orderId = event.orderId();
         Long deliveryId = event.deliveryId();
             try {
-                Thread.sleep(3000);
+                long randomSleep = (long) (Math.random() * 500) + 500;
+                Thread.sleep(randomSleep);
 
                 log.info("====== [가상 택배사] 배송 ID {} 배송 완료 처리 진행 ======", deliveryId);
                  sellerDeliveryService.completeDelivery(orderId, deliveryId);

--- a/src/main/java/com/example/i_commerce/domain/order/support/MockCourierComponent.java
+++ b/src/main/java/com/example/i_commerce/domain/order/support/MockCourierComponent.java
@@ -1,0 +1,52 @@
+package com.example.i_commerce.domain.order.support;
+
+
+import com.example.i_commerce.domain.order.event.dto.DeliveryStatusChangedEvent;
+import com.example.i_commerce.domain.order.service.SellerDeliveryService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Profile("k6")
+public class MockCourierComponent {
+
+    private final SellerDeliveryService sellerDeliveryService;
+
+    // 부하 테스트 시 결제/배송시작 API 스레드를 방해하지 않기 위한 독립 스레드 풀
+    @Bean(name = "courierThreadPool")
+    public ExecutorService courierThreadPool() {
+        return Executors.newFixedThreadPool(30, runnable -> {
+            Thread thread = new Thread(runnable);
+            thread.setName("mock-courier-thread-" + thread.getName());
+            return thread;
+        });
+    }
+
+    @Async("courierThreadPool")
+    @TransactionalEventListener(
+            phase = TransactionPhase.AFTER_COMMIT,
+            condition = "#event.currentStatus.name() == 'SHIPPING'"
+    )
+    public void onDeliveryStatusChanged(DeliveryStatusChangedEvent event) {
+        Long orderId = event.orderId();
+        Long deliveryId = event.deliveryId();
+            try {
+                Thread.sleep(3000);
+
+                System.out.println("====== [가상 택배사] 배송 ID " + deliveryId + " 배송 완료 처리 진행 ======");
+                 sellerDeliveryService.completeDelivery(orderId, deliveryId);
+
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+    }
+}

--- a/src/main/java/com/example/i_commerce/domain/order/support/MockCourierComponent.java
+++ b/src/main/java/com/example/i_commerce/domain/order/support/MockCourierComponent.java
@@ -3,14 +3,16 @@ package com.example.i_commerce.domain.order.support;
 
 import com.example.i_commerce.domain.order.event.dto.DeliveryStatusChangedEvent;
 import com.example.i_commerce.domain.order.service.SellerDeliveryService;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -25,12 +27,15 @@ public class MockCourierComponent {
 
     // 부하 테스트 시 결제/배송시작 API 스레드를 방해하지 않기 위한 독립 스레드 풀
     @Bean(name = "courierThreadPool")
-    public ExecutorService courierThreadPool() {
-        return Executors.newFixedThreadPool(30, runnable -> {
-            Thread thread = new Thread(runnable);
-            thread.setName("mock-courier-thread-" + thread.getName());
-            return thread;
-        });
+    public Executor courierThreadPool() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(30);
+        executor.setMaxPoolSize(30);
+        executor.setQueueCapacity(200);
+        executor.setThreadNamePrefix("mock-courier-thread-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.initialize();
+        return executor;
     }
 
     @Async("courierThreadPool")

--- a/src/main/java/com/example/i_commerce/domain/order/support/MockTossPaymentClient.java
+++ b/src/main/java/com/example/i_commerce/domain/order/support/MockTossPaymentClient.java
@@ -1,5 +1,6 @@
-package com.example.i_commerce.domain.order.client;
+package com.example.i_commerce.domain.order.support;
 
+import com.example.i_commerce.domain.order.client.PaymentClient;
 import com.example.i_commerce.domain.order.service.dto.PaymentCancelRequest;
 import com.example.i_commerce.domain.order.service.dto.PaymentConfirmRequest;
 import java.time.OffsetDateTime;

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -24,7 +24,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
-      ddl-auto: create-drop #update
+      ddl-auto: update #update
     show-sql: true
     open-in-view: false
 

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -24,7 +24,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
-      ddl-auto: update #update #create-drop
+      ddl-auto: create-drop #update
     show-sql: true
     open-in-view: false
 

--- a/src/test/java/com/example/i_commerce/domain/order/integration/concurrency_test/DeliveryConcurrencyTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/integration/concurrency_test/DeliveryConcurrencyTest.java
@@ -2,8 +2,12 @@ package com.example.i_commerce.domain.order.integration.concurrency_test;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 
 import com.example.i_commerce.common.IntegrationTestSupport;
+import com.example.i_commerce.domain.member.entity.Store;
+import com.example.i_commerce.domain.member.entity.enums.StoreStatus;
+import com.example.i_commerce.domain.member.repository.StoreRepository;
 import com.example.i_commerce.domain.order.client.PaymentClient;
 import com.example.i_commerce.domain.order.client.TossPaymentClient;
 import com.example.i_commerce.domain.order.entity.Delivery;
@@ -55,6 +59,9 @@ class DeliveryConcurrencyTest extends IntegrationTestSupport {
     @Autowired
     private PaymentRepository paymentRepository;
 
+    @Autowired
+    private StoreRepository storeRepository;
+
     @MockitoBean // 스프링 부트 3.4+ 버전 기준 (구버전은 @MockBean 사용)
     private PaymentClient tossPaymentClient;
 
@@ -65,6 +72,8 @@ class DeliveryConcurrencyTest extends IntegrationTestSupport {
     private StockEventListener stockEventListener;
 
     private Long testOrderId;
+    private Long testSellerId;
+    private Long testStoreId;
     private Long testDeliveryId;
     private String testTossOrderId;
     private String testPaymentKey = "toss-payment-key-12345";
@@ -83,15 +92,26 @@ class DeliveryConcurrencyTest extends IntegrationTestSupport {
         testOrderId = savedOrder.getId();
 
         // Delivery를 생성하고 Order에 추가한 뒤 저장 (cascade 연쇄저장)
+        testSellerId = 1L;
+
+
+        Store savedStore = storeRepository.save(Store.builder()
+                .sellerId(testSellerId)
+                .phoneNumber("01012341234")
+                .storeName("상점")
+                .storeStatus(StoreStatus.OPEN)
+                .build());
+        testStoreId = savedStore.getId();
+
         Delivery delivery = Delivery.builder()
-                .storeId(1L)
+                .storeId(testStoreId)
                 .deliveryStatus(DeliveryStatus.PREPARING)
                 .order(savedOrder)
                 .build();
 
         savedOrder.getDeliveries().add(delivery);
         Order updated = orderRepository.save(savedOrder);
-        testDeliveryId = updated.getDeliveries().get(0).getId();
+        testDeliveryId = updated.getDeliveries().getFirst().getId();
 
         // Payment 생성: 고유한 tossOrderId와 pgTid 설정
         testTossOrderId = "toss-" + java.util.UUID.randomUUID();
@@ -127,7 +147,7 @@ class DeliveryConcurrencyTest extends IntegrationTestSupport {
         PaymentCancelRequest cancelRequest = new PaymentCancelRequest(
                 testTossOrderId,  50000, testPaymentKey,"고객 단순 변심"
         );
-        DeliveryShipRequest shipRequest = new DeliveryShipRequest(testDeliveryId, "TRACK-001");
+        DeliveryShipRequest shipRequest = new DeliveryShipRequest(testOrderId, testStoreId, testDeliveryId, "TRACK-001");
 
         given(tossPaymentClient.requestCanceled(any(PaymentCancelRequest.class))).willReturn(
                 Map.of("paymentKey", testPaymentKey)
@@ -146,7 +166,7 @@ class DeliveryConcurrencyTest extends IntegrationTestSupport {
 
         executorService.submit(() -> {
             try {
-                sellerDeliveryService.shipDelivery(shipRequest);
+                sellerDeliveryService.shipDelivery(testSellerId, shipRequest);
                 shipSuccess.set(true);
             } catch (Exception e) {
                 exceptions.add(e);

--- a/src/test/java/com/example/i_commerce/domain/order/integration/concurrency_test/DeliveryLifecycleIntegrationTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/integration/concurrency_test/DeliveryLifecycleIntegrationTest.java
@@ -1,0 +1,126 @@
+package com.example.i_commerce.domain.order.integration.concurrency_test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.example.i_commerce.common.OrderIntegrationTestSupport;
+import com.example.i_commerce.domain.member.entity.Store;
+import com.example.i_commerce.domain.member.entity.enums.StoreStatus;
+import com.example.i_commerce.domain.member.repository.StoreRepository;
+import com.example.i_commerce.domain.order.entity.Delivery;
+import com.example.i_commerce.domain.order.entity.Order;
+import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
+import com.example.i_commerce.domain.order.exception.DeliveryErrorCode;
+import com.example.i_commerce.domain.order.service.SellerDeliveryService;
+import com.example.i_commerce.domain.order.service.dto.DeliveryShipRequest;
+import com.example.i_commerce.domain.order.support.MockCourierComponent;
+import com.example.i_commerce.global.exception.AppException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles({"test", "k6"})
+public class DeliveryLifecycleIntegrationTest extends OrderIntegrationTestSupport {
+
+    @Autowired
+    private MockCourierComponent mockCourierComponent;
+
+    @Autowired
+    private SellerDeliveryService sellerDeliveryService;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    private Long testOrderId;
+    private Long testSellerId = 1L;
+    private Long testStoreId;
+    private Long preparingDeliveryId;
+    private Long shippingDeliveryId;
+
+    @BeforeEach
+    void setUp() {
+        Order order = Order.builder()
+                .userId(1L)
+                .totalProductAmount(10000)
+                .totalPayAmount(10000)
+                .build();
+
+        Order savedOrder = orderRepository.save(order);
+        testOrderId = savedOrder.getId();
+
+        Store savedStore = storeRepository.save(Store.builder()
+                .sellerId(testSellerId)
+                .phoneNumber("01012341234")
+                .storeName("상점")
+                .storeStatus(StoreStatus.OPEN)
+                .build());
+        testStoreId = savedStore.getId();
+
+        Delivery preparing = Delivery.builder()
+                .storeId(testStoreId)
+                .deliveryStatus(DeliveryStatus.PREPARING)
+                .order(savedOrder)
+                .build();
+
+        Delivery shipping = Delivery.builder()
+                .storeId(testStoreId)
+                .deliveryStatus(DeliveryStatus.SHIPPING)
+                .order(savedOrder)
+                .build();
+
+        savedOrder.getDeliveries().add(preparing);
+        savedOrder.getDeliveries().add(shipping);
+
+        Order updated = orderRepository.save(savedOrder);
+
+        preparingDeliveryId = updated.getDeliveries().getFirst().getId();
+        shippingDeliveryId = updated.getDeliveries().getLast().getId();
+    }
+
+    @Test
+    @DisplayName("판매자가 이미 배송중인 상품을 다시 출고시도하면 CANNOT_SHIP_STATUS 예외가 발생한다")
+    void cannotShipWhenNotPreparing() {
+        DeliveryShipRequest shipRequest = new DeliveryShipRequest(testOrderId, testStoreId, shippingDeliveryId, "TRACK-0001");
+
+        AppException ex = assertThrows(AppException.class, () ->
+                sellerDeliveryService.shipDelivery(testSellerId, shipRequest)
+        );
+
+        assertEquals(DeliveryErrorCode.CANNOT_SHIP_STATUS, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("판매자가 배송 시작시 상태가 SHIPPING으로 바뀌고, 가상 택배사가 배송 완료 처리 후 ARRIVED가 된다")
+    void shipThenCourierCompletesDelivery() throws InterruptedException {
+        DeliveryShipRequest shipRequest = new DeliveryShipRequest(testOrderId, testStoreId, preparingDeliveryId, "TRACK-0002");
+
+        sellerDeliveryService.shipDelivery(testSellerId, shipRequest);
+
+        Delivery afterShip = deliveryRepository.findById(preparingDeliveryId).orElseThrow();
+        assertThat(afterShip.getDeliveryStatus()).isEqualTo(DeliveryStatus.SHIPPING);
+
+        // MockCourierComponent sleeps ~500-1000ms before calling completeDelivery.
+        // 폴링으로 ARRIVED 상태를 최대 5초까지 기다린다.
+        long timeoutMs = 5000;
+        long start = System.currentTimeMillis();
+        boolean arrived = false;
+        while (System.currentTimeMillis() - start < timeoutMs) {
+            Delivery current = deliveryRepository.findById(preparingDeliveryId).orElseThrow();
+            if (current.getDeliveryStatus() == DeliveryStatus.ARRIVED) {
+                arrived = true;
+                break;
+            }
+            Thread.sleep(200);
+        }
+
+        assertThat(arrived).isTrue();
+        Delivery finalDelivery = deliveryRepository.findById(preparingDeliveryId).orElseThrow();
+        assertThat(finalDelivery.getDeliveryStatus()).isEqualTo(DeliveryStatus.ARRIVED);
+    }
+
+}

--- a/src/test/java/com/example/i_commerce/domain/order/unit/service/OrderServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/unit/service/OrderServiceTest.java
@@ -2,6 +2,7 @@
 package com.example.i_commerce.domain.order.unit.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -15,8 +16,12 @@ import com.example.i_commerce.domain.member.service.delivery.DeliveryAddressServ
 import com.example.i_commerce.domain.member.service.delivery.dto.DeliveryAddressSnapshot;
 import com.example.i_commerce.domain.member.service.member.MemberService;
 import com.example.i_commerce.domain.member.service.member.dto.MemberOrderInfo;
+import com.example.i_commerce.domain.order.entity.Delivery;
 import com.example.i_commerce.domain.order.entity.Order;
 import com.example.i_commerce.domain.order.entity.Payment;
+import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
+import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
+import com.example.i_commerce.domain.order.repository.DeliveryRepository;
 import com.example.i_commerce.domain.order.repository.OrderProductRepository;
 import com.example.i_commerce.domain.order.repository.OrderRepository;
 import com.example.i_commerce.domain.order.repository.PaymentRepository;
@@ -65,6 +70,9 @@ class OrderServiceTest {
     OrderProductRepository orderProductRepository;
 
     @Mock
+    DeliveryRepository deliveryRepository;
+
+    @Mock
     StockFacade stockFacade;
 
     @InjectMocks
@@ -109,6 +117,17 @@ class OrderServiceTest {
         return payment;
     }
 
+    private UpdateOrderStatusTestSet createTestSet(Long orderId, DeliveryStatus deliveryStatus1, DeliveryStatus deliveryStatus2) {
+        Order order = Order.builder().id(orderId).build();
+
+        Delivery delivery1 = Delivery.builder().deliveryStatus(deliveryStatus1).build();
+        Delivery delivery2 = Delivery.builder().deliveryStatus(deliveryStatus2).build();
+        return new UpdateOrderStatusTestSet(order, List.of(delivery1, delivery2));
+    }
+
+    private record UpdateOrderStatusTestSet(Order order, List<Delivery> deliveries) {
+    }
+
 
     @Test
     @DisplayName("성공: 다중 상품 주문 시 총액이 정확히 계산되고 저장된다")
@@ -141,7 +160,6 @@ class OrderServiceTest {
 
         then(orderRepository).should().save(argThat(order ->
                 order.getTotalProductAmount() == 35000 &&
-//                        order.getZipCode().equals(OrderFixture.ZIP_CODE) &&
                         order.getOrderProducts().size() == 2
         ));
 
@@ -202,6 +220,117 @@ class OrderServiceTest {
         AppException e = assertThrows(AppException.class, () -> orderService.getOrderDetail(orderId, invalidUserId));
         assertEquals("ORDER_NOT_FOUND", e.getErrorCode().toString());
     }
+
+    @Test
+    @DisplayName("모든 배송이 완료(ARRIVED)되면 주문 상태는 배송완료(DELIVERED)가 된다.")
+    void orderStatusBecomesDeliveredWhenAllDeliveriesArrived() {
+        // given
+        Long orderId = 1L;
+        UpdateOrderStatusTestSet testSet = createTestSet(orderId, DeliveryStatus.ARRIVED, DeliveryStatus.ARRIVED);
+        Order order = testSet.order;
+
+        ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.CONFIRMED);
+
+        List<Delivery> deliveries = testSet.deliveries;
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(deliveryRepository.findAllByOrderId(orderId)).willReturn(deliveries);
+
+        // when
+        orderService.updateOrderStatusByDeliveries(orderId);
+
+        // then
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.DELIVERED);
+    }
+
+    @Test
+    @DisplayName("모든 배송이 중(SHIPPING)이면 주문 상태는 배송중(SHIPPING)이 된다.")
+    void orderStatusBecomesShippingWhenAllDeliveriesShipping() {
+        // given
+        Long orderId = 1L;
+        UpdateOrderStatusTestSet testSet = createTestSet(orderId, DeliveryStatus.SHIPPING, DeliveryStatus.SHIPPING);
+        Order order = testSet.order;
+
+        ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.CONFIRMED);
+
+        List<Delivery> deliveries = testSet.deliveries;
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(deliveryRepository.findAllByOrderId(orderId)).willReturn(deliveries);
+
+        // when
+        orderService.updateOrderStatusByDeliveries(orderId);
+
+        // then
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.SHIPPING);
+    }
+
+    @Test
+    @DisplayName("배송 완료(ARRIVED) 건이 하나라도 존재하면 주문 상태는 부분배송완료(PARTIAL_DELIVERED)가 된다.")
+    void orderStatusBecomesPartialDeliveredWhenAnyDeliveryArrived() {
+        // given
+        Long orderId = 1L;
+        UpdateOrderStatusTestSet testSet = createTestSet(orderId, DeliveryStatus.SHIPPING, DeliveryStatus.ARRIVED);
+        Order order = testSet.order;
+
+        ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.CONFIRMED);
+
+        List<Delivery> deliveries = testSet.deliveries;
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(deliveryRepository.findAllByOrderId(orderId)).willReturn(deliveries);
+
+        // when
+        orderService.updateOrderStatusByDeliveries(orderId);
+
+        // then
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.PARTIAL_DELIVERED);
+    }
+
+    @Test
+    @DisplayName("배송중(SHIPPING) 건이 하나라도 존재하고 완료 건이 없으면 주문 상태는 부분배송중(PARTIAL_SHIPPING)이 된다.")
+    void orderStatusBecomesPartialShippingWhenAnyDeliveryShippingAndNoArrived() {
+        // given
+        Long orderId = 1L;
+        UpdateOrderStatusTestSet testSet = createTestSet(orderId, DeliveryStatus.PREPARING, DeliveryStatus.SHIPPING);
+        Order order = testSet.order;
+
+        ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.CONFIRMED);
+
+        List<Delivery> deliveries = testSet.deliveries;
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(deliveryRepository.findAllByOrderId(orderId)).willReturn(deliveries);
+
+        // when
+        orderService.updateOrderStatusByDeliveries(orderId);
+
+        // then
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.PARTIAL_SHIPPING);
+    }
+
+    @Test
+    @DisplayName("배송중이나 배송완료 상태가 없으면 주문 상태는 주문확정(CONFIRMED)을 유지한다.")
+    void orderStatusRemainsConfirmedWhenNoShippingOrArrivedDeliveries() {
+        // given
+        Long orderId = 1L;
+        UpdateOrderStatusTestSet testSet = createTestSet(orderId, DeliveryStatus.PREPARING, DeliveryStatus.PREPARING);
+        Order order = testSet.order;
+
+        ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.CONFIRMED);
+
+        List<Delivery> deliveries = testSet.deliveries;
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(deliveryRepository.findAllByOrderId(orderId)).willReturn(deliveries);
+
+        // when
+        orderService.updateOrderStatusByDeliveries(orderId);
+
+        // then
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.CONFIRMED);
+    }
+
 
     public static class OrderFixture {
         public static final Long MEMBER_ID = 1L;

--- a/src/test/java/com/example/i_commerce/domain/order/unit/service/OrderServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/unit/service/OrderServiceTest.java
@@ -2,6 +2,7 @@
 package com.example.i_commerce.domain.order.unit.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -15,8 +16,12 @@ import com.example.i_commerce.domain.member.service.delivery.DeliveryAddressServ
 import com.example.i_commerce.domain.member.service.delivery.dto.DeliveryAddressSnapshot;
 import com.example.i_commerce.domain.member.service.member.MemberService;
 import com.example.i_commerce.domain.member.service.member.dto.MemberOrderInfo;
+import com.example.i_commerce.domain.order.entity.Delivery;
 import com.example.i_commerce.domain.order.entity.Order;
 import com.example.i_commerce.domain.order.entity.Payment;
+import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
+import com.example.i_commerce.domain.order.entity.emuns.OrderStatus;
+import com.example.i_commerce.domain.order.repository.DeliveryRepository;
 import com.example.i_commerce.domain.order.repository.OrderProductRepository;
 import com.example.i_commerce.domain.order.repository.OrderRepository;
 import com.example.i_commerce.domain.order.repository.PaymentRepository;
@@ -63,6 +68,11 @@ class OrderServiceTest {
     @Mock
     OrderProductRepository orderProductRepository;
 
+    @Mock
+    DeliveryRepository deliveryRepository;
+
+    @Mock
+    StockFacade stockFacade;
 
     @InjectMocks
     OrderService orderService;
@@ -106,6 +116,17 @@ class OrderServiceTest {
         return payment;
     }
 
+    private UpdateOrderStatusTestSet createTestSet(Long orderId, DeliveryStatus deliveryStatus1, DeliveryStatus deliveryStatus2) {
+        Order order = Order.builder().id(orderId).build();
+
+        Delivery delivery1 = Delivery.builder().deliveryStatus(deliveryStatus1).build();
+        Delivery delivery2 = Delivery.builder().deliveryStatus(deliveryStatus2).build();
+        return new UpdateOrderStatusTestSet(order, List.of(delivery1, delivery2));
+    }
+
+    private record UpdateOrderStatusTestSet(Order order, List<Delivery> deliveries) {
+    }
+
 
     @Test
     @DisplayName("성공: 다중 상품 주문 시 총액이 정확히 계산되고 저장된다")
@@ -138,7 +159,6 @@ class OrderServiceTest {
 
         then(orderRepository).should().save(argThat(order ->
                 order.getTotalProductAmount() == 35000 &&
-//                        order.getZipCode().equals(OrderFixture.ZIP_CODE) &&
                         order.getOrderProducts().size() == 2
         ));
 
@@ -199,6 +219,117 @@ class OrderServiceTest {
         AppException e = assertThrows(AppException.class, () -> orderService.getOrderDetail(orderId, invalidUserId));
         assertEquals("ORDER_NOT_FOUND", e.getErrorCode().toString());
     }
+
+    @Test
+    @DisplayName("모든 배송이 완료(ARRIVED)되면 주문 상태는 배송완료(DELIVERED)가 된다.")
+    void orderStatusBecomesDeliveredWhenAllDeliveriesArrived() {
+        // given
+        Long orderId = 1L;
+        UpdateOrderStatusTestSet testSet = createTestSet(orderId, DeliveryStatus.ARRIVED, DeliveryStatus.ARRIVED);
+        Order order = testSet.order;
+
+        ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.CONFIRMED);
+
+        List<Delivery> deliveries = testSet.deliveries;
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(deliveryRepository.findAllByOrderId(orderId)).willReturn(deliveries);
+
+        // when
+        orderService.updateOrderStatusByDeliveries(orderId);
+
+        // then
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.DELIVERED);
+    }
+
+    @Test
+    @DisplayName("모든 배송이 중(SHIPPING)이면 주문 상태는 배송중(SHIPPING)이 된다.")
+    void orderStatusBecomesShippingWhenAllDeliveriesShipping() {
+        // given
+        Long orderId = 1L;
+        UpdateOrderStatusTestSet testSet = createTestSet(orderId, DeliveryStatus.SHIPPING, DeliveryStatus.SHIPPING);
+        Order order = testSet.order;
+
+        ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.CONFIRMED);
+
+        List<Delivery> deliveries = testSet.deliveries;
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(deliveryRepository.findAllByOrderId(orderId)).willReturn(deliveries);
+
+        // when
+        orderService.updateOrderStatusByDeliveries(orderId);
+
+        // then
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.SHIPPING);
+    }
+
+    @Test
+    @DisplayName("배송 완료(ARRIVED) 건이 하나라도 존재하면 주문 상태는 부분배송완료(PARTIAL_DELIVERED)가 된다.")
+    void orderStatusBecomesPartialDeliveredWhenAnyDeliveryArrived() {
+        // given
+        Long orderId = 1L;
+        UpdateOrderStatusTestSet testSet = createTestSet(orderId, DeliveryStatus.SHIPPING, DeliveryStatus.ARRIVED);
+        Order order = testSet.order;
+
+        ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.CONFIRMED);
+
+        List<Delivery> deliveries = testSet.deliveries;
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(deliveryRepository.findAllByOrderId(orderId)).willReturn(deliveries);
+
+        // when
+        orderService.updateOrderStatusByDeliveries(orderId);
+
+        // then
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.PARTIAL_DELIVERED);
+    }
+
+    @Test
+    @DisplayName("배송중(SHIPPING) 건이 하나라도 존재하고 완료 건이 없으면 주문 상태는 부분배송중(PARTIAL_SHIPPING)이 된다.")
+    void orderStatusBecomesPartialShippingWhenAnyDeliveryShippingAndNoArrived() {
+        // given
+        Long orderId = 1L;
+        UpdateOrderStatusTestSet testSet = createTestSet(orderId, DeliveryStatus.PREPARING, DeliveryStatus.SHIPPING);
+        Order order = testSet.order;
+
+        ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.CONFIRMED);
+
+        List<Delivery> deliveries = testSet.deliveries;
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(deliveryRepository.findAllByOrderId(orderId)).willReturn(deliveries);
+
+        // when
+        orderService.updateOrderStatusByDeliveries(orderId);
+
+        // then
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.PARTIAL_SHIPPING);
+    }
+
+    @Test
+    @DisplayName("배송중이나 배송완료 상태가 없으면 주문 상태는 주문확정(CONFIRMED)을 유지한다.")
+    void orderStatusRemainsConfirmedWhenNoShippingOrArrivedDeliveries() {
+        // given
+        Long orderId = 1L;
+        UpdateOrderStatusTestSet testSet = createTestSet(orderId, DeliveryStatus.PREPARING, DeliveryStatus.PREPARING);
+        Order order = testSet.order;
+
+        ReflectionTestUtils.setField(order, "orderStatus", OrderStatus.CONFIRMED);
+
+        List<Delivery> deliveries = testSet.deliveries;
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(deliveryRepository.findAllByOrderId(orderId)).willReturn(deliveries);
+
+        // when
+        orderService.updateOrderStatusByDeliveries(orderId);
+
+        // then
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.CONFIRMED);
+    }
+
 
     public static class OrderFixture {
         public static final Long MEMBER_ID = 1L;

--- a/src/test/java/com/example/i_commerce/domain/order/unit/service/OrderServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/unit/service/OrderServiceTest.java
@@ -71,9 +71,6 @@ class OrderServiceTest {
     @Mock
     DeliveryRepository deliveryRepository;
 
-    @Mock
-    StockFacade stockFacade;
-
     @InjectMocks
     OrderService orderService;
 

--- a/src/test/java/com/example/i_commerce/domain/order/unit/service/SellerDeliveryServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/unit/service/SellerDeliveryServiceTest.java
@@ -76,7 +76,7 @@ class SellerDeliveryServiceTest {
                     .isInstanceOf(AppException.class)
                     .hasMessage(DeliveryErrorCode.STORE_FORBIDDEN.getMessage());
 
-            verify(deliveryRepository, never()).findBWithOrderById(any());
+            verify(deliveryRepository, never()).findWithOrderById(any());
         }
 
         @Test
@@ -86,7 +86,7 @@ class SellerDeliveryServiceTest {
             Store store = mock(Store.class);
             given(store.getSellerId()).willReturn(sellerId);
             given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
-            given(deliveryRepository.findBWithOrderById(deliveryId)).willReturn(Optional.empty());
+            given(deliveryRepository.findWithOrderById(deliveryId)).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> sellerDeliveryService.shipDelivery(sellerId, request))
@@ -95,7 +95,7 @@ class SellerDeliveryServiceTest {
         }
 
         @Test
-        @DisplayName("[실패 케이스 3] 주문 ID가 일치하지 않으면 CANNOT_SHIP_STATUS 예외")
+        @DisplayName("[실패 케이스 3] 주문 ID가 일치하지 않으면 INVALID_DELIVERY_ORDER 예외")
         void shipDelivery_InvalidOrderId_CannotShipStatus() {
             // given
             Store store = mock(Store.class);
@@ -107,12 +107,12 @@ class SellerDeliveryServiceTest {
 
             Delivery delivery = mock(Delivery.class);
             given(delivery.getOrder()).willReturn(order);
-            given(deliveryRepository.findBWithOrderById(deliveryId)).willReturn(Optional.of(delivery));
+            given(deliveryRepository.findWithOrderById(deliveryId)).willReturn(Optional.of(delivery));
 
             // when & then
             assertThatThrownBy(() -> sellerDeliveryService.shipDelivery(sellerId, request))
                     .isInstanceOf(AppException.class)
-                    .hasMessage(DeliveryErrorCode.CANNOT_SHIP_STATUS.getMessage());
+                    .hasMessage(DeliveryErrorCode.INVALID_DELIVERY_ORDER.getMessage());
 
         }
         @Test
@@ -132,7 +132,7 @@ class SellerDeliveryServiceTest {
                     .storeId(storeId)
                     .deliveryStatus(DeliveryStatus.CANCEL_REQUESTED)
                     .build();
-            given(deliveryRepository.findBWithOrderById(deliveryId)).willReturn(Optional.of(delivery));
+            given(deliveryRepository.findWithOrderById(deliveryId)).willReturn(Optional.of(delivery));
 
             // when & then
             assertThatThrownBy(() -> sellerDeliveryService.shipDelivery(sellerId, request))
@@ -159,7 +159,7 @@ class SellerDeliveryServiceTest {
                     .storeId(storeId)
                     .deliveryStatus(DeliveryStatus.PREPARING)
                     .build();
-            given(deliveryRepository.findBWithOrderById(deliveryId)).willReturn(Optional.of(delivery));
+            given(deliveryRepository.findWithOrderById(deliveryId)).willReturn(Optional.of(delivery));
 
             // when
             ApiResponse<Void> response = sellerDeliveryService.shipDelivery(sellerId, request);
@@ -181,7 +181,7 @@ class SellerDeliveryServiceTest {
         private final Pageable pageable = PageRequest.of(0, 10);
 
         @Test
-        @DisplayName("[실패 케이스] 요청한 사장님ID와 가게의 사장님ID가 다를 때 -> DELIVERY_NOT_FOUND 예외")
+        @DisplayName("[실패 케이스] 요청한 사장님ID와 가게의 사장님ID가 다를 때 -> STORE_FORBIDDEN 예외")
         void getDeliveryList_StoreForbidden() {
             // given
             Store wrongStore = mock(Store.class);
@@ -192,7 +192,7 @@ class SellerDeliveryServiceTest {
             assertThatThrownBy(() -> sellerDeliveryService.getDeliveryList(sellerId, storeId, status, pageable))
                     .isInstanceOf(AppException.class)
                     .extracting("errorCode")
-                    .isEqualTo(DeliveryErrorCode.DELIVERY_NOT_FOUND);
+                    .isEqualTo(DeliveryErrorCode.STORE_FORBIDDEN);
 
             verify(deliveryRepository, never()).findAllByStoreId(any(), any(), any());
         }

--- a/src/test/java/com/example/i_commerce/domain/order/unit/service/SellerDeliveryServiceTest.java
+++ b/src/test/java/com/example/i_commerce/domain/order/unit/service/SellerDeliveryServiceTest.java
@@ -1,0 +1,241 @@
+package com.example.i_commerce.domain.order.unit.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.example.i_commerce.domain.member.entity.Store;
+import com.example.i_commerce.domain.member.repository.StoreRepository;
+import com.example.i_commerce.domain.order.entity.Delivery;
+import com.example.i_commerce.domain.order.entity.Order;
+import com.example.i_commerce.domain.order.entity.emuns.DeliveryStatus;
+import com.example.i_commerce.domain.order.event.dto.DeliveryStatusChangedEvent;
+import com.example.i_commerce.domain.order.exception.DeliveryErrorCode;
+import com.example.i_commerce.domain.order.repository.DeliveryRepository;
+import com.example.i_commerce.domain.order.service.SellerDeliveryService;
+import com.example.i_commerce.domain.order.service.dto.DeliveryResponse;
+import com.example.i_commerce.domain.order.service.dto.DeliveryShipRequest;
+import com.example.i_commerce.global.common.response.ApiResponse;
+import com.example.i_commerce.global.exception.AppException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class SellerDeliveryServiceTest {
+
+    @Mock
+    DeliveryRepository deliveryRepository;
+    @Mock
+    StoreRepository storeRepository;
+    @Mock
+    ApplicationEventPublisher publisher;
+
+    @InjectMocks
+    SellerDeliveryService sellerDeliveryService;
+
+    @Nested
+    @DisplayName("shipDelivery - 배송 처리 테스트")
+    class ShipDeliveryTest {
+
+        private final Long sellerId = 1L;
+        private final Long storeId = 10L;
+        private final Long deliveryId = 100L;
+        private final Long orderId = 1000L;
+        private final String trackingNumber = "TRK123456789";
+
+        private final DeliveryShipRequest request = new DeliveryShipRequest(orderId, storeId, deliveryId, trackingNumber);
+
+        @Test
+        @DisplayName("[실패 케이스 1] 요청한 사장님ID와 가게의 사장님ID가 다를 때 -> STORE_FORBIDDEN 예외")
+        void shipDelivery_StoreForbidden() {
+            // given
+            Store wrongStore = mock(Store.class);
+            given(wrongStore.getSellerId()).willReturn(999L); // 다른 사장님 ID
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(wrongStore));
+
+            // when & then
+            assertThatThrownBy(() -> sellerDeliveryService.shipDelivery(sellerId, request))
+                    .isInstanceOf(AppException.class)
+                    .hasMessage(DeliveryErrorCode.STORE_FORBIDDEN.getMessage());
+
+            verify(deliveryRepository, never()).findBWithOrderById(any());
+        }
+
+        @Test
+        @DisplayName("[실패 케이스 2] 존재하지 않는 배달 ID를 요청했을 때 -> DELIVERY_NOT_FOUND 예외")
+        void shipDelivery_DeliveryNotFound() {
+            // given
+            Store store = mock(Store.class);
+            given(store.getSellerId()).willReturn(sellerId);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+            given(deliveryRepository.findBWithOrderById(deliveryId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> sellerDeliveryService.shipDelivery(sellerId, request))
+                    .isInstanceOf(AppException.class)
+                    .hasMessage(DeliveryErrorCode.DELIVERY_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("[실패 케이스 3] 주문 ID가 일치하지 않으면 CANNOT_SHIP_STATUS 예외")
+        void shipDelivery_InvalidOrderId_CannotShipStatus() {
+            // given
+            Store store = mock(Store.class);
+            given(store.getSellerId()).willReturn(sellerId);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+
+            Order order = mock(Order.class);
+            given(order.getId()).willReturn(999L); // request.orderId()와 일치하게 설정
+
+            Delivery delivery = mock(Delivery.class);
+            given(delivery.getOrder()).willReturn(order);
+            given(deliveryRepository.findBWithOrderById(deliveryId)).willReturn(Optional.of(delivery));
+
+            // when & then
+            assertThatThrownBy(() -> sellerDeliveryService.shipDelivery(sellerId, request))
+                    .isInstanceOf(AppException.class)
+                    .hasMessage(DeliveryErrorCode.CANNOT_SHIP_STATUS.getMessage());
+
+        }
+        @Test
+        @DisplayName("[실패 케이스] 배송 상태가 PREPARING이 아닐 때 CANNOT_SHIP_STATUS")
+        void shipDelivery_NotPreparingStatus_CannotShipStatus() {
+            // given
+            Store store = mock(Store.class);
+            given(store.getSellerId()).willReturn(sellerId);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+
+            Order order = mock(Order.class);
+            given(order.getId()).willReturn(orderId); // 실패조건3을 피하기 위해 request.orderId()와 다르게 설정
+
+            Delivery delivery = Delivery.builder()
+                    .id(deliveryId)
+                    .order(order)
+                    .storeId(storeId)
+                    .deliveryStatus(DeliveryStatus.CANCEL_REQUESTED)
+                    .build();
+            given(deliveryRepository.findBWithOrderById(deliveryId)).willReturn(Optional.of(delivery));
+
+            // when & then
+            assertThatThrownBy(() -> sellerDeliveryService.shipDelivery(sellerId, request))
+                    .isInstanceOf(AppException.class)
+                    .hasMessage(DeliveryErrorCode.CANNOT_SHIP_STATUS.getMessage());
+            verify(publisher, never()).publishEvent(any(DeliveryStatusChangedEvent.class)); // 이벤트 1회 발행 검증
+        }
+
+
+        @Test
+        @DisplayName("[성공 케이스] 모든 조건이 올바를 때 -> 운송장 등록 및 이벤트 발행")
+        void shipDelivery_Success() {
+            // given
+            Store store = mock(Store.class);
+            given(store.getSellerId()).willReturn(sellerId);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+
+            Order order = mock(Order.class);
+            given(order.getId()).willReturn(orderId); // 실패조건3을 피하기 위해 request.orderId()와 다르게 설정
+
+            Delivery delivery = Delivery.builder()
+                    .id(deliveryId)
+                    .order(order)
+                    .storeId(storeId)
+                    .deliveryStatus(DeliveryStatus.PREPARING)
+                    .build();
+            given(deliveryRepository.findBWithOrderById(deliveryId)).willReturn(Optional.of(delivery));
+
+            // when
+            ApiResponse<Void> response = sellerDeliveryService.shipDelivery(sellerId, request);
+
+            // then
+            assertThat(response.code()).isEqualTo("SUCCESS"); // ApiResponse 구조에 맞게 검증 (성공여부 메서드명 수정 가능)
+            assertThat(delivery.getDeliveryStatus()).isEqualTo(DeliveryStatus.SHIPPING);
+            verify(publisher, times(1)).publishEvent(any(DeliveryStatusChangedEvent.class)); // 이벤트 1회 발행 검증
+        }
+    }
+
+    @Nested
+    @DisplayName("getDeliveryList - 페이징 조회 테스트")
+    class GetDeliveryListTest {
+
+        private final Long sellerId = 1L;
+        private final Long storeId = 10L;
+        private final DeliveryStatus status = DeliveryStatus.SHIPPING;
+        private final Pageable pageable = PageRequest.of(0, 10);
+
+        @Test
+        @DisplayName("[실패 케이스] 요청한 사장님ID와 가게의 사장님ID가 다를 때 -> DELIVERY_NOT_FOUND 예외")
+        void getDeliveryList_StoreForbidden() {
+            // given
+            Store wrongStore = mock(Store.class);
+            given(wrongStore.getSellerId()).willReturn(999L);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(wrongStore));
+
+            // when & then
+            assertThatThrownBy(() -> sellerDeliveryService.getDeliveryList(sellerId, storeId, status, pageable))
+                    .isInstanceOf(AppException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(DeliveryErrorCode.DELIVERY_NOT_FOUND);
+
+            verify(deliveryRepository, never()).findAllByStoreId(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("[성공 케이스] 정상적인 페이징 및 필터링 조회 -> DTO 변환 확인")
+        void getDeliveryList_Success() {
+            // given
+            Store store = mock(Store.class);
+            given(store.getSellerId()).willReturn(sellerId);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+
+            // 가짜 딜리버리와 주문 세팅
+            Order mockOrder = mock(Order.class);
+            given(mockOrder.getId()).willReturn(555L);
+
+            Delivery mockDelivery = mock(Delivery.class);
+            given(mockDelivery.getId()).willReturn(100L);
+            given(mockDelivery.getDeliveryStatus()).willReturn(DeliveryStatus.SHIPPING);
+            given(mockDelivery.getCreatedAt()).willReturn(LocalDateTime.now());
+            given(mockDelivery.getOrder()).willReturn(mockOrder);
+
+            // Page 객체 생성
+            Page<Delivery> deliveryPage = new PageImpl<>(List.of(mockDelivery), pageable, 1);
+            given(deliveryRepository.findAllByStoreId(storeId, status, pageable)).willReturn(deliveryPage);
+
+            // when
+            ApiResponse<Page<DeliveryResponse>> response = sellerDeliveryService.getDeliveryList(sellerId, storeId, status, pageable);
+
+            // then
+            assertThat(response).isNotNull();
+            Page<DeliveryResponse> resultPage = response.data(); // ApiResponse에 getData()가 있다고 가정
+
+            assertThat(resultPage.getContent().size()).isEqualTo(1);
+
+            // DTO로 누락 없이 정확하게 매핑되었는지 필드 개별 검증
+            DeliveryResponse dto = resultPage.getContent().getFirst();
+            assertThat(dto.orderId()).isEqualTo(555L);
+            assertThat(dto.deliveryId()).isEqualTo(100L);
+            assertThat(dto.status()).isEqualTo(DeliveryStatus.SHIPPING);
+
+            verify(deliveryRepository, times(1)).findAllByStoreId(storeId, status, pageable);
+        }
+    }
+
+}


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
closed #170

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
- 판매자용 배송 상태 변경 API 구현 ('배송중' 전환 기능)
- 배송 상태 조회 API 구현
- 배송 상태 변경 및 조회 로직에 대한 단위/통합 테스트 코드 작성
- 부하테스트용 Mock 택배사 서버 환경 설계 및 스케레톤 코드 생성
- Mock 택배사 서버의 더미 응답 API 구현 (송장 조회, 배송 완료 등)

## 😅 Uncompleted Tasks
[//]: # (없다면 N/A)
- [ ] Task1

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)

## 📃 RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
